### PR TITLE
Merging iniData models to support loading of multiple ini files into one structure

### DIFF
--- a/src/IniFileParser.Tests/Unit/Model/IniDataTests.cs
+++ b/src/IniFileParser.Tests/Unit/Model/IniDataTests.cs
@@ -29,6 +29,90 @@ namespace IniFileParser.Tests.Unit.Model
 			
 			Console.WriteLine(iniData.ToString());
         }
+
+        string iniFileStrA =
+@"
+g = 1
+[s0]
+a = 2
+[s1]
+a = 3
+b = 4
+";
+
+        string iniFileStrB =
+@"
+g = 11
+j = a
+[s0]
+a = 22
+b = 44
+
+[s2]
+c = 55
+";
+
+        [Test]
+        public void merge_multiple_inis()
+        {
+            var parser = new IniParser.Parser.IniDataParser();
+
+            IniData dataA = parser.Parse(iniFileStrA);
+
+            Assert.That(dataA, Is.Not.Null);
+
+            {
+                // first file
+                Assert.That(dataA.Global["g"], Is.EqualTo("1"));
+                Assert.That(dataA.Sections.Count, Is.EqualTo(2), "Expected two (2) sections");
+
+                var s0 = dataA.Sections.GetSectionData("s0");
+
+                Assert.That(s0, Is.Not.Null);
+                Assert.That(s0.SectionName, Is.EqualTo("s0"));
+                Assert.That(s0.Keys["a"], Is.EqualTo("2"));
+
+                var s1 = dataA.Sections.GetSectionData("s1");
+
+                Assert.That(s1, Is.Not.Null);
+                Assert.That(s1.SectionName, Is.EqualTo("s1"));
+                Assert.That(s1.Keys["a"], Is.EqualTo("3"));
+                Assert.That(s1.Keys["b"], Is.EqualTo("4"));
+            }
+
+            IniData dataB = parser.Parse(iniFileStrB);
+            dataA.Merge(dataB);
+
+            {
+                // merged files
+                Assert.That(dataA.Global["g"], Is.EqualTo("11"));
+                Assert.That(dataA.Global["j"], Is.EqualTo("a"));
+                Assert.That(dataA.Sections.Count, Is.EqualTo(3), "Expected two (3) sections");
+
+                var s0 = dataA.Sections.GetSectionData("s0");
+
+                Assert.That(s0, Is.Not.Null);
+                Assert.That(s0.SectionName, Is.EqualTo("s0"));
+                Assert.That(s0.Keys["a"], Is.EqualTo("22"));
+                Assert.That(s0.Keys["b"], Is.EqualTo("44"));
+
+                var s1 = dataA.Sections.GetSectionData("s1");
+
+                Assert.That(s1, Is.Not.Null);
+                Assert.That(s1.SectionName, Is.EqualTo("s1"));
+                Assert.That(s1.Keys["a"], Is.EqualTo("3"));
+                Assert.That(s1.Keys["b"], Is.EqualTo("4"));
+
+                var s2 = dataA.Sections.GetSectionData("s2");
+
+                Assert.That(s2, Is.Not.Null);
+                Assert.That(s2.SectionName, Is.EqualTo("s2"));
+                Assert.That(s2.Keys["c"], Is.EqualTo("55"));
+            }
+
+
+
+        }
     }
 }
 

--- a/src/IniFileParser/Model/IniData.cs
+++ b/src/IniFileParser/Model/IniData.cs
@@ -142,5 +142,51 @@ namespace IniParser.Model
         /// </summary>
         private IIniParserConfiguration _configuration;
         #endregion
+
+        /// <summary>
+        /// Merges the other iniData into this one by overwriting existing values.
+        /// Comments get appended.
+        /// </summary>
+        /// <param name="other"></param>
+        public void Merge(IniData other)
+        {
+            if (other != null)
+            {
+                MergeGlobal(other.Global);
+
+                foreach(var otherSection in other._sections)
+                {
+                    MergeSection(otherSection);
+                }
+            }
+        }
+
+        /// <summary>
+        /// Merge the sections into this by overwriting this sections.
+        /// </summary>
+        /// <param name="otherSection"></param>
+        private void MergeSection(SectionData otherSection)
+        {
+            // no overlap -> create no section
+            if (!Sections.ContainsSection(otherSection.SectionName))
+            {
+                Sections.AddSection(otherSection.SectionName);
+            }
+
+            // merge section into the new one
+            Sections.GetSectionData(otherSection.SectionName).Merge(otherSection);
+        }
+
+        /// <summary>
+        /// Merges the given global values into this globals by overwriting existing values.
+        /// </summary>
+        /// <param name="globals"></param>
+        private void MergeGlobal(KeyDataCollection globals)
+        {
+            foreach(var globalValue in globals)
+            {
+                Global[globalValue.KeyName] = globalValue.Value;
+            }
+        }
     }
 } 

--- a/src/IniFileParser/Model/SectionData.cs
+++ b/src/IniFileParser/Model/SectionData.cs
@@ -171,5 +171,22 @@ namespace IniParser.Model
         private string _sectionName;
         #endregion
 
+
+        /// <summary>
+        /// Merges the other section into this one by overwriting values.
+        /// Comments get appended.
+        /// </summary>
+        /// <param name="otherSection"></param>
+        public void Merge(SectionData otherSection)
+        {
+            // comments
+            foreach (var comment in otherSection._leadingComments) _leadingComments.Add(comment);
+            foreach (var comment in otherSection._trailingComments) _trailingComments.Add(comment);
+            // values
+            foreach (var pair in otherSection._keyDataCollection)
+            {
+                _keyDataCollection[pair.KeyName] = pair.Value;
+            }
+        }
     }
 }


### PR DESCRIPTION
Ini files (iniData) can be merged by overwriting:

iniData a = ...
iniData b = ...
a.Merge(b); // merges content of b by overwriting into a

I reused an existing test file that there is no need to change a csproj.

Original PR: https://github.com/rickyah/ini-parser/pull/46
