### PR TITLE
added data value type with implicit conversion

### DIFF
--- a/src/IniFileParser.Tests/INIFileParser.Tests.csproj
+++ b/src/IniFileParser.Tests/INIFileParser.Tests.csproj
@@ -81,6 +81,7 @@
     <Compile Include="issues\Issue2Tests.cs" />
     <Compile Include="issues\Issue32Tests.cs" />
     <Compile Include="Unit\Configuration\ConfigurationTests.cs" />
+    <Compile Include="Unit\Model\DataTests.cs" />
     <Compile Include="Unit\Model\DefaultIniDataConfigurationTests.cs" />
     <Compile Include="Unit\Parser\ParserDefaultConfigurationTests.cs" />
     <Compile Include="Unit\Model\SectionDataCollectionTests.cs" />

--- a/src/IniFileParser.Tests/Unit/Model/DataTests.cs
+++ b/src/IniFileParser.Tests/Unit/Model/DataTests.cs
@@ -1,0 +1,161 @@
+﻿using System;
+using System.Collections.Generic;
+using System.ComponentModel;
+using System.Globalization;
+using System.Text;
+using IniParser.Model;
+using NUnit.Framework;
+
+namespace IniFileParser.Tests.Unit.Model
+{
+    [TestFixture, NUnit.Framework.Category("Test of data used to hold information retrieved for an INI file")]
+    public class DataTests
+    {
+        [Test]
+        public void check_to_string()
+        {
+            Data data = "data value";
+            Assert.That((string)data, Is.EqualTo("data value"));
+        }
+
+        [Test]
+        public void check_to_char_from_char()
+        {
+            Data data = 'd';
+            Assert.That((char)data, Is.EqualTo('d'));
+        }
+
+        [Test]
+        public void check_to_char_from_string()
+        {
+            Data data = "d";
+            Assert.That((char)data, Is.EqualTo('d'));
+        }
+
+        [Test]
+        public void check_to_int16_from_int()
+        {
+            Data data = 42;
+            Assert.That((Int16)data, Is.EqualTo((Int16)42));
+        }
+
+        [Test]
+        public void check_to_int16_from_string()
+        {
+            Data data = "42";
+            Assert.That((Int16)data, Is.EqualTo((Int16)42));
+        }
+
+        [Test]
+        public void check_to_int32_from_int()
+        {
+            Data data = 42;
+            Assert.That((Int32)data, Is.EqualTo(42));
+        }
+
+        [Test]
+        public void check_to_int32_from_string()
+        {
+            Data data = "42";
+            Assert.That((Int32)data, Is.EqualTo(42));
+        }
+
+        [Test]
+        public void check_to_int64_from_int()
+        {
+            Data data = 42;
+            Assert.That((Int64)data, Is.EqualTo((Int64)42));
+        }
+
+        [Test]
+        public void check_to_int64_from_string()
+        {
+            Data data = "42";
+            Assert.That((Int64)data, Is.EqualTo((Int64)42));
+        }
+
+        [Test]
+        public void check_to_bool_from_bool()
+        {
+            Data data = true;
+            Assert.That((bool)data, Is.EqualTo(true));
+        }
+
+        [Test]
+        public void check_to_bool_from_string()
+        {
+            Data data = "True";
+            Assert.That((bool)data, Is.EqualTo(true));
+        }
+
+        [Test]
+        public void check_to_byte_from_byte()
+        {
+            Data data = 42;
+            Assert.That((byte)data, Is.EqualTo((byte)42));
+        }
+
+        [Test]
+        public void check_to_byte_from_string()
+        {
+            Data data = "42";
+            Assert.That((byte)data, Is.EqualTo((byte)42));
+        }
+
+        [Test]
+        public void check_to_DateTime_from_DateTime()
+        {
+            Data data = new DateTime(2014, 06, 22, 15, 04, 33);
+            Assert.That((DateTime)data, Is.EqualTo(new DateTime(2014, 06, 22, 15, 04, 33)));
+        }
+
+        [Test]
+        public void check_to_DateTime_from_string()
+        {
+            Data data = "06/22/2014 15:04:33";
+            Assert.That((DateTime)data, Is.EqualTo(new DateTime(2014, 06, 22, 15, 04, 33)));
+        }
+
+        [Test]
+        public void check_to_decimal_from_decimal()
+        {
+            Data data = 4.2;
+            Assert.That((decimal)data, Is.EqualTo((decimal)4.2));
+        }
+
+        [Test]
+        public void check_to_decimal_from_string()
+        {
+            Data data = "4.2";
+            Assert.That((decimal)data, Is.EqualTo((decimal)4.2));
+        }
+
+        [Test]
+        public void check_to_double_from_double()
+        {
+            Data data = 4.2;
+            Assert.That((double)data, Is.EqualTo(4.2));
+        }
+
+        [Test]
+        public void check_to_double_from_string()
+        {
+            Data data = "4.2";
+            Assert.That((double)data, Is.EqualTo(4.2));
+        }
+
+        [Test]
+        public void check_to_single_from_single()
+        {
+            Data data = 4.2;
+            Assert.That((float)data, Is.EqualTo((float)4.2));
+        }
+
+        [Test]
+        public void check_to_single_from_string()
+        {
+            Data data = "4.2";
+            Assert.That((float)data, Is.EqualTo((float)4.2));
+        }
+    }
+}

--- a/src/IniFileParser/INIFileParser.csproj
+++ b/src/IniFileParser/INIFileParser.csproj
@@ -64,6 +64,7 @@
   <ItemGroup>
     <Compile Include="Helpers\Assert.cs" />
     <Compile Include="FileIniParser.cs" />
+    <Compile Include="Model\Data.cs" />
     <Compile Include="Model\IniData.cs" />
     <Compile Include="Model\KeyData.cs" />
     <Compile Include="Model\KeyDataCollection.cs" />

--- a/src/IniFileParser/Model/Data.cs
+++ b/src/IniFileParser/Model/Data.cs
@@ -1,0 +1,201 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Globalization;
+using System.Text;
+
+namespace IniParser.Model
+{
+    public class Data
+    {
+        private readonly string _data;
+
+        public Data(string data)
+        {
+            _data = data;
+        }
+
+        #region Export
+        public static implicit operator Char(Data data)
+        {
+            try
+            {
+                return Convert.ToChar(data._data, CultureInfo.InvariantCulture);
+            }
+            catch
+            {
+                return '\0';
+            }
+        }
+
+        public static implicit operator String(Data data)
+        {
+            return data._data;
+        }
+
+        public static implicit operator bool(Data data)
+        {
+            try
+            {
+                return Convert.ToBoolean(data._data, CultureInfo.InvariantCulture);
+            }
+            catch
+            {
+                return false;
+            }
+        }
+
+        public static implicit operator Byte(Data data)
+        {
+            try
+            {
+                return Convert.ToByte(data._data, CultureInfo.InvariantCulture);
+            }
+            catch
+            {
+                return 0;
+            }
+        }
+
+        public static implicit operator Int16(Data data)
+        {
+            try
+            {
+                return Convert.ToInt16(data._data, CultureInfo.InvariantCulture);
+            }
+            catch
+            {
+                return 0;
+            }
+        }
+
+        public static implicit operator Int32(Data data)
+        {
+            try
+            {
+                return Convert.ToInt32(data._data, CultureInfo.InvariantCulture);
+            }
+            catch
+            {
+                return 0;
+            }
+        }
+
+        public static implicit operator Int64(Data data)
+        {
+            try
+            {
+                return Convert.ToInt64(data._data, CultureInfo.InvariantCulture);
+            }
+            catch
+            {
+                return 0;
+            }
+        }
+
+        public static implicit operator DateTime(Data data)
+        {
+            try
+            {
+                return Convert.ToDateTime(data._data, CultureInfo.InvariantCulture);
+            }
+            catch
+            {
+                return DateTime.UtcNow;
+            }
+        }
+
+        public static implicit operator Single(Data data)
+        {
+            try
+            {
+                return Convert.ToSingle(data._data, CultureInfo.InvariantCulture);
+            }
+            catch
+            {
+                return 0;
+            }
+        }
+
+        public static implicit operator Double(Data data)
+        {
+            try
+            {
+                return Convert.ToDouble(data._data, CultureInfo.InvariantCulture);
+            }
+            catch
+            {
+                return 0;
+            }
+        }
+
+        public static implicit operator Decimal(Data data)
+        {
+            try
+            {
+                return Convert.ToDecimal(data._data, CultureInfo.InvariantCulture);
+            }
+            catch
+            {
+                return 0;
+            }
+        }
+        #endregion
+
+        #region Import
+        public static implicit operator Data(Char data)
+        {
+            return new Data(data.ToString(CultureInfo.InvariantCulture));
+        }
+
+        public static implicit operator Data(String data)
+        {
+            return new Data(data);
+        }
+
+        public static implicit operator Data(bool data)
+        {
+            return new Data(data.ToString(CultureInfo.InvariantCulture));
+        }
+
+        public static implicit operator Data(Byte data)
+        {
+            return new Data(data.ToString(CultureInfo.InvariantCulture));
+        }
+
+        public static implicit operator Data(Int16 data)
+        {
+            return new Data(data.ToString(CultureInfo.InvariantCulture));
+        }
+
+        public static implicit operator Data(Int32 data)
+        {
+            return new Data(data.ToString(CultureInfo.InvariantCulture));
+        }
+
+        public static implicit operator Data(Int64 data)
+        {
+            return new Data(data.ToString(CultureInfo.InvariantCulture));
+        }
+
+        public static implicit operator Data(DateTime data)
+        {
+            return new Data(data.ToString(CultureInfo.InvariantCulture));
+        }
+
+        public static implicit operator Data(Single data)
+        {
+            return new Data(data.ToString(CultureInfo.InvariantCulture));
+        }
+
+        public static implicit operator Data(Double data)
+        {
+            return new Data(data.ToString(CultureInfo.InvariantCulture));
+        }
+
+        public static implicit operator Data(Decimal data)
+        {
+            return new Data(data.ToString(CultureInfo.InvariantCulture));
+        }
+        #endregion
+    }
+}


### PR DESCRIPTION
I am a very lazy developer and don't want to convert all string values to their primitives. Therefor I created a new class (Data) which does implicit conversions to all CLS compatible primitive types as well as DateTime.
As it does implicit conversions to strings as well, this change is completly backwards compatible.
