### PR TITLE
Update FileIniParser.cs

### DIFF
--- a/src/IniFileParser/FileIniParser.cs
+++ b/src/IniFileParser/FileIniParser.cs
@@ -56,7 +56,9 @@ namespace IniParser
 
             try
             {
-                using (FileStream fs = File.Open(filePath, FileMode.Open, FileAccess.Read))
+                // (FileAccess.Read) we want to open the ini only for reading 
+                // (FileShare.ReadWrite) any other process should still have access to the ini file 
+                using (FileStream fs = File.Open(filePath, FileMode.Open, FileAccess.Read, FileShare.ReadWrite))
                 {
                     using (StreamReader sr = new StreamReader(fs, fileEncoding))
                     {


### PR DESCRIPTION
When FileIniDataParser reads a ini file no other process has access to this file because it opens it in an exclusive read mode. I've changed the FileShare attribute of the FileStream to ReadWrite.