### PR TITLE
Provide better error messages when parsing fails

### DIFF
--- a/src/IniFileParser.Tests/INIFileParser.Tests.csproj
+++ b/src/IniFileParser.Tests/INIFileParser.Tests.csproj
@@ -96,6 +96,7 @@
     <Compile Include="Unit\Model\MergeIniFiles.cs" />
     <Compile Include="Unit\Model\INIDataTests.cs" />
     <Compile Include="issues\Issue66Tests.cs" />
+    <Compile Include="issues\Issue67Tests.cs" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\IniFileParser\INIFileParser.csproj">

--- a/src/IniFileParser.Tests/issues/Issue66Tests.cs
+++ b/src/IniFileParser.Tests/issues/Issue66Tests.cs
@@ -31,4 +31,5 @@ namespace IniFileParser.Tests.issues
                             ;end
                             ";
     }
+
 }

--- a/src/IniFileParser.Tests/issues/Issue67Tests.cs
+++ b/src/IniFileParser.Tests/issues/Issue67Tests.cs
@@ -1,0 +1,58 @@
+using IniParser.Parser;
+using NUnit.Framework;
+using IniParser.Exceptions;
+
+namespace IniFileParser.Tests.issues
+{
+
+    [TestFixture]
+    public class Issue67Tests
+    {
+        IniDataParser parser;
+        [SetUp]
+        public void Setup()
+        {
+            parser = new IniDataParser();
+        }
+        // Thanks https://github.com/RichardSinden for this issue
+        [Test ,Description("Test for Issue 67 - better errors")]
+        public void provides_error_data()
+        {
+
+            parser.Configuration.ThrowExceptionsOnError = true;
+
+            try
+            {
+               parser.Parse(iniDataString);
+            }
+            catch(ParsingException ex)
+            {
+                Assert.That(ex.LineNumber, Is.EqualTo(5));
+                Assert.That(parser.HasError, Is.True);
+                Assert.That(parser.Errors, Has.Count.EqualTo(1));
+            }
+     
+        }
+
+        [Test ,Description("Test for Issue 67 - better errors")]
+        public void provides_a_list_of_errors()
+        {
+            parser.Configuration.ThrowExceptionsOnError = false;
+            parser.Configuration.AllowDuplicateKeys = false;
+
+            var result = parser.Parse(iniDataString);
+
+            Assert.That(result, Is.Null);
+            Assert.That(parser.HasError, Is.True);
+            Assert.That(parser.Errors, Has.Count.EqualTo(2));
+
+        }
+        const string iniDataString = @";begin
+
+                            ;value
+                            value1 = test
+                                = test2
+                            value1 = test3
+                            ";
+    }
+}

--- a/src/IniFileParser/Exceptions/ParsingException.cs
+++ b/src/IniFileParser/Exceptions/ParsingException.cs
@@ -7,19 +7,26 @@ namespace IniParser.Exceptions
     /// </summary>
     public class ParsingException : Exception
     {
-        /// <summary>
-        /// Initializes a new instance of the <see cref="ParsingException"/> class.
-        /// </summary>
-        /// <param name="msg">The message describing the exception cause.</param>
-        public ParsingException(string msg)
-            : base("Parsing Error: " + msg) { }
+        public int LineNumber {get; private set;}
+        public string LineValue {get; private set;}
 
-        /// <summary>
-        /// Initializes a new instance of the <see cref="ParsingException"/> class.
-        /// </summary>
-        /// <param name="msg">The message describing the exception cause.</param>
-        /// <param name="innerException">An inner exception.</param>
+        public ParsingException(string msg)
+            :this(msg, 0, string.Empty, null) 
+        {}
+
         public ParsingException(string msg, Exception innerException)
-            : base("Parsing Error: " + msg, innerException) { }
+            :this(msg, 0, string.Empty, innerException) 
+        {}
+
+        public ParsingException(string msg, int lineNumber, string lineValue)
+            :this(msg, lineNumber, lineValue, null)
+        {}
+            
+        public ParsingException(string msg, int lineNumber, string lineValue, Exception innerException)
+            : base(string.Format("Error \'{2}\' while parsing line {1}: \'{0}\'", lineValue, lineNumber, msg), innerException) 
+        { 
+            LineNumber = lineNumber;
+            LineValue = lineValue;
+        }
     }
 }

--- a/src/IniFileParser/Parser/IniDataParser.cs
+++ b/src/IniFileParser/Parser/IniDataParser.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using IniParser.Exceptions;
 using IniParser.Model;
 using IniParser.Model.Configuration;
+using System.Collections.ObjectModel;
 
 namespace IniParser.Parser
 {
@@ -12,6 +13,11 @@ namespace IniParser.Parser
 	/// </summary>
     public class IniDataParser
     {
+        #region Private
+        // Holds a list of the exceptions catched while parsing
+        private List<Exception> _errorExceptions;
+        #endregion
+
         #region Initialization
         /// <summary>
         ///     Ctor
@@ -35,6 +41,8 @@ namespace IniParser.Parser
                 throw new ArgumentNullException("parserConfiguration");
 
             Configuration = parserConfiguration;
+
+            _errorExceptions = new List<Exception>();
         }
 
         #endregion
@@ -45,9 +53,29 @@ namespace IniParser.Parser
         ///     that the parser must follow.
         /// </summary>
         public IIniParserConfiguration Configuration { get; private set; }
+
+        /// <summary>
+        /// True is the parsing operation encounter any problem
+        /// </summary>
+        public bool HasError { get { return _errorExceptions.Count > 0; } }
+
+        /// <summary>
+        /// Returns the list of errors found while parsing the ini file.
+        /// </summary>
+        /// <remarks>
+        /// If the configuration option ThrowExceptionOnError is false it can contain one element
+        /// for each problem found while parsing; otherwise it will only contain the very same 
+        /// exception that was raised.
+        /// </remarks>
+
+        public ReadOnlyCollection<Exception> Errors {get {return _errorExceptions.AsReadOnly();} }
 		#endregion
 
 		#region Operations
+
+
+
+
         /// <summary>
         ///     Parses a string containing valid ini data
         /// </summary>
@@ -71,15 +99,36 @@ namespace IniParser.Parser
                 return iniData;
             }
 
+            _errorExceptions.Clear();
             _currentCommentListTemp.Clear();
             _currentSectionNameTemp = null;
 
             try
             {
-                var lines = iniDataString.Split(Environment.NewLine.ToCharArray(), StringSplitOptions.RemoveEmptyEntries);
-                foreach (var line in lines)
+                var lines = iniDataString.Split(Environment.NewLine.ToCharArray());
+                for (int lineNumber = 0; lineNumber < lines.Length; lineNumber++)
                 {
-                    ProcessLine(line, iniData);
+                    var line = lines[lineNumber];
+
+                    if (line.Trim() == String.Empty) continue;
+
+                    try
+                    {
+                        ProcessLine(line, iniData);
+                    }
+                    catch (Exception ex)
+                    {
+                        var errorEx = new ParsingException(ex.Message, lineNumber+1, line, ex);
+                        if (Configuration.ThrowExceptionsOnError) 
+                        {
+                            throw errorEx;
+                        }
+                        else
+                        {
+                            _errorExceptions.Add(errorEx);
+                        }
+
+                    }
                 }
 
                 // Orphan comments, assing to last section/key value
@@ -104,14 +153,17 @@ namespace IniParser.Parser
                 }
 
             }
-            catch
+            catch(Exception ex)
             {
-                if (Configuration.ThrowExceptionsOnError)
+                _errorExceptions.Add(ex);
+                if (Configuration.ThrowExceptionsOnError) 
+                { 
                     throw;
-
-                return null;
+                }
             }
 
+
+            if (HasError) return null;
             return (IniData)iniData.Clone();
         }
         #endregion
@@ -289,8 +341,6 @@ namespace IniParser.Parser
         /// </param>
         protected virtual void ProcessKeyValuePair(string line, IniData currentIniData)
         {
-            //string sectionToUse = _currentSectionNameTemp;
-
             // get key and value data
             string key = ExtractKey(line);
             string value = ExtractValue(line);


### PR DESCRIPTION
* The exception ParseException contains a string with the line and and int with the line number that originated the error.
* IniDataParser.HasError returns true if IniDataParser.Parse() encounter a problem
* IniDataParser.Errors returns a list with all the ParsingExceptions found when IniDataParser.Parse() is called. Will be empty if no error is found.

There are two use cases depending on the configuration option you choose:

* Throw an exception when a call to IniDataParser.Parse() fails:
The Exception is still thrown.
IniDataParser.HasError returns true
IniDataParser.Errors contains one element (the ParsingException thrown)

* Throw an exception when a call to IniParser.Parse() fails:
In this case the Parse() method tries to process all the lines in the ini file, but The call to IniParser.Parser() returns null to keep backward compatibility.
IniDataParser.HasError returns true
IniDataParser.Errors contains one ParsingException instance for each error found when parsing the file. (It will at least contain one ParsingException instance)