### PR TITLE
Allows access to ini file elements using case insensitive names

### DIFF
--- a/src/IniFileParser.Tests/INIFileParser.Tests.csproj
+++ b/src/IniFileParser.Tests/INIFileParser.Tests.csproj
@@ -97,6 +97,7 @@
     <Compile Include="Unit\Model\INIDataTests.cs" />
     <Compile Include="issues\Issue66Tests.cs" />
     <Compile Include="issues\Issue67Tests.cs" />
+    <Compile Include="issues\Issue76Tests.cs" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\IniFileParser\INIFileParser.csproj">

--- a/src/IniFileParser.Tests/issues/Issue76Tests.cs
+++ b/src/IniFileParser.Tests/issues/Issue76Tests.cs
@@ -1,0 +1,49 @@
+using IniParser;
+using IniParser.Model;
+using NUnit.Framework;
+using IniParser.Parser;
+using IniParser.Model.Configuration;
+
+namespace IniFileParser.Tests.Unit
+{
+    [TestFixture]
+    public class Issue76Tests
+    {
+        [Test, Description("Test for Issue 76: https://github.com/rickyah/ini-parser/issues/76")]
+        public void resolve_case_insensitive_names()
+        {
+
+            var data = new IniDataCaseInsensitive();
+            var section = new SectionData("TestSection");
+            section.Keys.AddKey("keY1", "value1");
+            section.Keys.AddKey("KEY2", "value2");
+            section.Keys.AddKey("KeY2", "value3");
+
+            data.Sections.Add(section);
+
+            Assert.That(data.Sections.ContainsSection("testsection"));
+            Assert.That(data.Sections.ContainsSection("TestSection"));
+            Assert.That(data["TestSection"]["key1"], Is.EqualTo("value1"));
+            Assert.That(data["TestSection"]["keY1"], Is.EqualTo("value1"));
+            Assert.That(data["TestSection"]["KEY2"], Is.EqualTo("value3"));
+            Assert.That(data["TestSection"]["KeY2"], Is.EqualTo("value3"));
+            Assert.That(data["TestSection"]["key2"], Is.EqualTo("value3"));
+        }
+
+        [Test]
+        public void parse_case_insensitive_names_ini_file()
+        {
+            string iniData = @"[TestSection]
+            KEY1 = value1
+            KEY2 = value2";
+
+            var config = new DefaultIniParserConfiguration();
+            config.CaseInsensitive = true;
+            var data = new IniDataParser(config).Parse(iniData);
+
+            Assert.That(data["testsection"]["key1"], Is.EqualTo("value1"));
+            Assert.That(data["testSection"]["Key2"], Is.EqualTo("value2"));
+
+        }
+    }
+}

--- a/src/IniFileParser/INIFileParser.csproj
+++ b/src/IniFileParser/INIFileParser.csproj
@@ -79,6 +79,7 @@
     <Compile Include="Exceptions\ParsingException.cs" />
     <Compile Include="Model\Formatting\DefaultIniDataFormatter.cs" />
     <Compile Include="Model\Formatting\IIniDataFormatter.cs" />
+    <Compile Include="Model\IniDataCaseInsensitive.cs" />
   </ItemGroup>
   <ItemGroup>
     <None Include="INIFileParser.nuspec" />

--- a/src/IniFileParser/Model/Configuration/BaseIniParserConfiguration.cs
+++ b/src/IniFileParser/Model/Configuration/BaseIniParserConfiguration.cs
@@ -13,6 +13,7 @@ namespace IniParser.Model.Configuration
     /// <see cref="IniDataParser.Configuration"/>
     public class BaseIniParserConfiguration : IIniParserConfiguration
     {
+    
         #region Initialization
         /// <summary>
         ///     Ctor.
@@ -41,15 +42,10 @@ namespace IniParser.Model.Configuration
         }
         #endregion
 
-        #region State
-        /// <summary>
-        ///     Regular expression for matching a comment string
-        /// </summary>
+        #region IIniParserConfiguration
+        
         public Regex CommentRegex { get; set; }
 
-        /// <summary>
-        ///     Regular expression for matching a section string
-        /// </summary>
         public Regex SectionRegex { get; set; }
 
         /// <summary>
@@ -83,6 +79,15 @@ namespace IniParser.Model.Configuration
                 RecreateSectionRegex(_sectionEndChar);
             }
         }
+
+        /// <summary>
+        ///     Retrieving section / keys by name is done with a case-insensitive
+        ///     search.
+        /// </summary>
+        /// <remarks>
+        ///     Defaults to false (case sensitive search)
+        /// </remarks>
+        public bool CaseInsensitive{ get; set; }
 
         /// <summary>
         ///     Sets the char that defines the start of a comment.
@@ -283,8 +288,8 @@ namespace IniParser.Model.Configuration
         /// </returns>
         /// <filterpriority>2</filterpriority>
         public IIniParserConfiguration Clone()
-		{
-			return this.MemberwiseClone() as IIniParserConfiguration;
+        {
+            return this.MemberwiseClone() as IIniParserConfiguration;
         }
         #endregion
 

--- a/src/IniFileParser/Model/Configuration/IIniParserConfiguration.cs
+++ b/src/IniFileParser/Model/Configuration/IIniParserConfiguration.cs
@@ -61,6 +61,12 @@ namespace IniParser.Model.Configuration
         string AssigmentSpacer { get; set; }
         
         /// <summary>
+        ///     Retrieving section / keys by name is done with a case-insensitive
+        ///     search.
+        /// </summary>
+        bool CaseInsensitive {get; set;}
+
+        /// <summary>
         ///     Regular expression used to match a comment string
         /// </summary>
         Regex CommentRegex { get; set; }

--- a/src/IniFileParser/Model/IniData.cs
+++ b/src/IniFileParser/Model/IniData.cs
@@ -4,7 +4,6 @@ using IniParser.Model.Formatting;
 
 namespace IniParser.Model
 {
-    
     /// <summary>
     ///     Represents all data from an INI file
     /// </summary>
@@ -22,9 +21,9 @@ namespace IniParser.Model
         /// <summary>
         ///     Initializes an empty IniData instance.
         /// </summary>
-        public IniData() : this (new SectionDataCollection())
-        {
-        }
+        public IniData() 
+            :this(new SectionDataCollection())
+        { }
 
         /// <summary>
         ///     Initializes a new IniData instance using a previous
@@ -79,7 +78,7 @@ namespace IniParser.Model
         /// 	enclosed in any section (i.e. they are defined at the beginning 
         /// 	of the file, before any section.
         /// </summary>
-        public KeyDataCollection Global { get; private set; }
+        public KeyDataCollection Global { get; protected set; }
 
         /// <summary>
         /// Gets the <see cref="KeyDataCollection"/> instance 
@@ -89,11 +88,10 @@ namespace IniParser.Model
         {
             get
             {
-                if (_sections.ContainsSection(sectionName))
-                    return _sections[sectionName];
+                if (_sections.ContainsSection(sectionName)) return _sections[sectionName];
+
                 return null;
             }
-
         }
 
         /// <summary>

--- a/src/IniFileParser/Model/IniDataCaseInsensitive.cs
+++ b/src/IniFileParser/Model/IniDataCaseInsensitive.cs
@@ -1,0 +1,45 @@
+using System;
+using IniParser.Model.Configuration;
+using IniParser.Model.Formatting;
+
+namespace IniParser.Model
+{
+    /// <summary>
+    ///     Represents all data from an INI file exactly as the <see cref="IniData"/>
+    ///     class, but searching for sections and keys names is done with
+    ///     a case insensitive search.
+    /// </summary>
+    public class IniDataCaseInsensitive : IniData
+    {
+        /// <summary>
+        ///     Initializes an empty IniData instance.
+        /// </summary>
+        public IniDataCaseInsensitive() 
+            : base (new SectionDataCollection(StringComparer.OrdinalIgnoreCase))
+        {}
+
+        /// <summary>
+        ///     Initializes a new IniData instance using a previous
+        ///     <see cref="SectionDataCollection"/>.
+        /// </summary>
+        /// <param name="sdc">
+        ///     <see cref="SectionDataCollection"/> object containing the
+        ///     data with the sections of the file
+        /// </param>
+        public IniDataCaseInsensitive(SectionDataCollection sdc)
+            : base (new SectionDataCollection(sdc, StringComparer.OrdinalIgnoreCase))
+        {}
+
+        /// <summary>
+        /// Copies an instance of the <see cref="IniParser.Model.IniDataCaseInsensitive"/> class
+        /// </summary>
+        /// <param name="ori">Original </param>
+        public IniDataCaseInsensitive(IniData ori)
+            : this(new SectionDataCollection(ori.Sections, StringComparer.OrdinalIgnoreCase))
+        {
+            Global = (KeyDataCollection) ori.Global.Clone();
+            Configuration = ori.Configuration.Clone();
+        }
+    }
+    
+} 

--- a/src/IniFileParser/Model/KeyDataCollection.cs
+++ b/src/IniFileParser/Model/KeyDataCollection.cs
@@ -9,14 +9,23 @@ namespace IniParser.Model
     /// </summary>
     public class KeyDataCollection : ICloneable, IEnumerable<KeyData>
     {
+        IEqualityComparer<string> _searchComparer;
         #region Initialization
 
         /// <summary>
         /// Initializes a new instance of the <see cref="KeyDataCollection"/> class.
         /// </summary>
-        public KeyDataCollection()
+        public KeyDataCollection() 
+            :this(EqualityComparer<string>.Default)
+        {}
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="KeyDataCollection"/> class.
+        /// </summary>
+        public KeyDataCollection(IEqualityComparer<string> searchComparer)
         {
-            _keyData = new Dictionary<string, KeyData>();
+            _searchComparer = searchComparer;
+            _keyData = new Dictionary<string, KeyData>(_searchComparer);
         }
 
         /// <summary>
@@ -29,10 +38,20 @@ namespace IniParser.Model
         /// <param name="ori">
         /// The instance of the <see cref="KeyDataCollection"/> class 
         /// used to create the new instance.</param>
-        public KeyDataCollection(KeyDataCollection ori) : this()
+        public KeyDataCollection(KeyDataCollection ori, IEqualityComparer<string> searchComparer)
+            : this(searchComparer)
         {
             foreach ( KeyData key in ori)
-                _keyData.Add(key.KeyName, key);
+            {
+                if (_keyData.ContainsKey(key.KeyName))
+                {
+                    _keyData[key.KeyName] = key;
+                }
+                else
+                {
+                    _keyData.Add(key.KeyName, key);
+                }
+            }
         }
 
         #endregion
@@ -281,13 +300,14 @@ namespace IniParser.Model
         /// </returns>
         public object Clone()
         {
-            return new KeyDataCollection(this);
+            return new KeyDataCollection(this, _searchComparer);
         }
 
         #endregion
 
         #region Non-public Members
-        // Horrible hack for getting the last key value (if exists) w/out using LINQ
+        // Hack for getting the last key value (if exists) w/out using LINQ
+        // and maintain support for earlier versions of .NET
         internal KeyData GetLast()
         {
             KeyData result = null;

--- a/src/IniFileParser/Model/SectionData.cs
+++ b/src/IniFileParser/Model/SectionData.cs
@@ -9,20 +9,29 @@ namespace IniParser.Model
     /// </summary>
     public class SectionData : ICloneable
     {
+        IEqualityComparer<string> _searchComparer;
         #region Initialization
 
+        public SectionData(string sectionName)
+            :this(sectionName, EqualityComparer<string>.Default)
+        {
+            
+        }
         /// <summary>
         ///     Initializes a new instance of the <see cref="SectionData"/> class.
         /// </summary>
-        public SectionData(string sectionName)
+        public SectionData(string sectionName, IEqualityComparer<string> searchComparer)
         {
+            _searchComparer = searchComparer;
+
             if (string.IsNullOrEmpty(sectionName))
                 throw new ArgumentException("section name can not be empty");
 
             _leadingComments = new List<string>();
-            _keyDataCollection = new KeyDataCollection();
+            _keyDataCollection = new KeyDataCollection(_searchComparer);
             SectionName = sectionName;
         }
+
 
         /// <summary>
         ///     Initializes a new instance of the <see cref="SectionData"/> class
@@ -35,10 +44,13 @@ namespace IniParser.Model
         ///     The instance of the <see cref="SectionData"/> class 
         ///     used to create the new instance.
         /// </param>
-        public SectionData(SectionData ori)
+        /// <param name="searchComparer">
+        ///     Search comparer.
+        /// </param>
+        public SectionData(SectionData ori, IEqualityComparer<string> searchComparer = null)
         {
             _leadingComments = new List<string>(ori._leadingComments);
-            _keyDataCollection = new KeyDataCollection(ori._keyDataCollection);
+            _keyDataCollection = new KeyDataCollection(ori._keyDataCollection, searchComparer ?? ori._searchComparer);
         }
 
         #endregion

--- a/src/IniFileParser/Model/SectionDataCollection.cs
+++ b/src/IniFileParser/Model/SectionDataCollection.cs
@@ -9,14 +9,27 @@ namespace IniParser.Model
     /// </summary>
     public class SectionDataCollection : ICloneable, IEnumerable<SectionData>
     {
+        IEqualityComparer<string> _searchComparer;
         #region Initialization
 
         /// <summary>
         /// Initializes a new instance of the <see cref="SectionDataCollection"/> class.
         /// </summary>
         public SectionDataCollection()
+            :this(EqualityComparer<string>.Default)
+        {}
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="IniParser.Model.SectionDataCollection"/> class.
+        /// </summary>
+        /// <param name="searchComparer">
+        ///     StringComparer used when accessing section names
+        /// </param>
+        public SectionDataCollection(IEqualityComparer<string> searchComparer)
         {
-            _sectionData = new Dictionary<string, SectionData>();
+            _searchComparer = searchComparer;
+
+            _sectionData = new Dictionary<string, SectionData>(_searchComparer);
         }
 
         /// <summary>
@@ -29,9 +42,11 @@ namespace IniParser.Model
         /// <param name="ori">
         /// The instance of the <see cref="SectionDataCollection"/> class 
         /// used to create the new instance.</param>
-        public SectionDataCollection(SectionDataCollection ori)
+        public SectionDataCollection(SectionDataCollection ori, IEqualityComparer<string> searchComparer)
         {
-            _sectionData = new Dictionary<string, SectionData> (ori._sectionData);
+            _searchComparer = searchComparer ?? EqualityComparer<string>.Default;
+                
+            _sectionData = new Dictionary<string, SectionData> (ori._sectionData, _searchComparer);
         }
 
         #endregion
@@ -41,10 +56,7 @@ namespace IniParser.Model
         /// <summary>
         /// Returns the number of SectionData elements in the collection
         /// </summary>
-        public int Count
-        {
-            get { return _sectionData.Count; }
-        }
+        public int Count { get { return _sectionData.Count; } }
 
         /// <summary>
         /// Gets the key data associated to a specified section name.
@@ -85,7 +97,7 @@ namespace IniParser.Model
 
             if ( !ContainsSection(keyName) )
             {
-                _sectionData.Add( keyName, new SectionData(keyName) );
+                _sectionData.Add( keyName, new SectionData(keyName, _searchComparer) );
                 return true;
             }
 
@@ -100,11 +112,11 @@ namespace IniParser.Model
         {
             if (ContainsSection(data.SectionName))
             {
-                SetSectionData(data.SectionName, data);
+                SetSectionData(data.SectionName, new SectionData(data, _searchComparer));
             }
             else
             {
-                _sectionData.Add(data.SectionName, data);
+                _sectionData.Add(data.SectionName, new SectionData(data, _searchComparer));
             }
         }
         /// <summary>
@@ -165,7 +177,7 @@ namespace IniParser.Model
         /// </summary>
         /// <param name="sectionName"></param>
         /// <param name="data">The new <see cref="SectionData"/>instance.</param>
-        public void SetSectionData( string sectionName, SectionData data)
+        public void SetSectionData(string sectionName, SectionData data)
         {
             if ( data != null )
                 _sectionData[sectionName] = data;
@@ -226,7 +238,7 @@ namespace IniParser.Model
         /// </returns>
         public object Clone()
         {
-            return new SectionDataCollection(this);
+            return new SectionDataCollection(this, _searchComparer);
         }
 
         #endregion

--- a/src/IniFileParser/Parser/IniDataParser.cs
+++ b/src/IniFileParser/Parser/IniDataParser.cs
@@ -73,9 +73,6 @@ namespace IniParser.Parser
 
 		#region Operations
 
-
-
-
         /// <summary>
         ///     Parses a string containing valid ini data
         /// </summary>
@@ -91,7 +88,8 @@ namespace IniParser.Parser
         /// </exception>
         public IniData Parse(string iniDataString)
         {
-            IniData iniData = new IniData();
+            
+            IniData iniData = Configuration.CaseInsensitive ? new IniDataCaseInsensitive() : new IniData();
             iniData.Configuration = this.Configuration.Clone();
 
             if (string.IsNullOrEmpty(iniDataString))
@@ -171,24 +169,26 @@ namespace IniParser.Parser
         #region Template Method Design Pattern 
         // All this methods controls the parsing behaviour, so it can be modified 
         // in derived classes.
-        // See http://www.dofactory.com/Patterns/PatternTemplate.aspx for an explanation of this pattern.
-        // Probably for the most common cases you can change the parsing behavior using a custom configuration
-        // object rather than creating derived classes.
-        // See IIniParserConfiguration interface, and IniDataParser constructor to change the default
-		// configuration.
+        // See http://www.dofactory.com/Patterns/PatternTemplate.aspx for an
+        // explanation of this pattern.
+        // Probably for the most common cases you can change the parsing behavior
+        //  using a custom configuration object rather than creating derived classes.
+        // See IIniParserConfiguration interface, and IniDataParser constructor
+		//  to change the default configuration.
 
         /// <summary>
         ///     Checks if a given string contains a comment.
         /// </summary>
         /// <param name="line">
-        ///     The string to be checked.
+        ///     String with a line to be checked.
         /// </param>
         /// <returns>
         ///     <c>true</c> if any substring from s is a comment, <c>false</c> otherwise.
         /// </returns>
         protected virtual bool LineContainsAComment(string line)
         {
-            return !string.IsNullOrEmpty(line) && Configuration.CommentRegex.Match(line).Success;
+            return !string.IsNullOrEmpty(line) 
+                && Configuration.CommentRegex.Match(line).Success;
         }
 
         /// <summary>
@@ -202,7 +202,8 @@ namespace IniParser.Parser
         /// </returns>
         protected virtual bool LineMatchesASection(string line)
         {
-            return !string.IsNullOrEmpty(line) && Configuration.SectionRegex.Match(line).Success;
+            return !string.IsNullOrEmpty(line) 
+                && Configuration.SectionRegex.Match(line).Success;
         }
 
         /// <summary>


### PR DESCRIPTION
IIniParserConfiguration exposes a new boolean property: CaseInsensitive
When this property is true for a parser configuration instance
an IniDataParser instance parses a file ignoring case in section and
key names.
- Implementation notes

A new class has been added: IniDataCaseInsensitive. This class derives
from IniData and shares its interface, so both are completely
interchangeable, ensuring backwards compatibility.

SectionDataCollection and KeyDataCollection classes now admit an
IEqualityComparer<string> parameter that defines the comparer to use
when accessing the section and keydata elements inside this elements.
IniData classe uses IEqualityComparer<string>.Default as a default value
for the comparer which mimics the previous behaviour.
IniDataCaseInsensitive uses StringComparer.OrdinalIgnoreCase to allow
case-insensitive search.
