### PR TITLE
Correctly counts line numbers with either windows or unix line endings

### DIFF
--- a/src/IniFileParser/Parser/IniDataParser.cs
+++ b/src/IniFileParser/Parser/IniDataParser.cs
@@ -103,7 +103,7 @@ namespace IniParser.Parser
 
             try
             {
-                var lines = iniDataString.Split(Environment.NewLine.ToCharArray());
+                var lines = iniDataString.Split(new []{"\n", "\r\n"}, StringSplitOptions.None);
                 for (int lineNumber = 0; lineNumber < lines.Length; lineNumber++)
                 {
                     var line = lines[lineNumber];


### PR DESCRIPTION
I noticed that a unit test failed on windows because the "\r\n" line endings were counted as two lines.  Hard coding both line ending styles seems to be the only way to make it work correctly (using Environment.Newline causes windows line endings to work, but breaks unix line endings).