### PR TITLE
Two minor changes

### DIFF
--- a/src/IniFileParser/.editorconfig
+++ b/src/IniFileParser/.editorconfig
@@ -1,0 +1,7 @@
+﻿; Top-most EditorConfig file
+root = true
+
+; 4-column space indentation
+[*.cs]
+indent_style = space
+indent_size = 4

--- a/src/IniFileParser/INIFileParser.csproj
+++ b/src/IniFileParser/INIFileParser.csproj
@@ -83,6 +83,7 @@
     <Compile Include="Model\Configuration\ConcatenateDuplicatedKeysIniParserConfiguration.cs" />
   </ItemGroup>
   <ItemGroup>
+    <None Include=".editorconfig" />
     <None Include="INIFileParser.nuspec" />
     <None Include="Properties\publickey.snk" />
   </ItemGroup>

--- a/src/IniFileParser/Model/Configuration/IniParserConfiguration.cs
+++ b/src/IniFileParser/Model/Configuration/IniParserConfiguration.cs
@@ -57,7 +57,9 @@ namespace IniParser.Model.Configuration
             AllowDuplicateSections = false;
             ThrowExceptionsOnError = true;
             SkipInvalidLines = false;
-        }
+			CommentsAfterLine = false;
+
+		}
 
         /// <summary>
         ///     Copy ctor.
@@ -76,9 +78,10 @@ namespace IniParser.Model.Configuration
             SectionEndChar = ori.SectionEndChar;
             CommentString = ori.CommentString;
             ThrowExceptionsOnError = ori.ThrowExceptionsOnError;
+			CommentsAfterLine = ori.CommentsAfterLine;
 
-          // Regex values should recreate themselves.
-        }
+		  // Regex values should recreate themselves.
+		}
         #endregion
 
         #region IniParserConfiguration
@@ -167,13 +170,18 @@ namespace IniParser.Model.Configuration
             }
         }
 
-        /// <summary>
-        ///     Sets the char that defines a value assigned to a key
-        /// </summary>
-        /// <remarks>
-        ///     Defaults to character '='
-        /// </remarks>
-        public char KeyValueAssigmentChar { get; set; }
+		/// <summary>
+		///    If set to true the leading comments of the sections are placed after the section's declaration and the comments of the key-value pair are placed after each line
+		/// </summary>
+		public bool CommentsAfterLine { get; set; }
+
+		/// <summary>
+		///     Sets the char that defines a value assigned to a key
+		/// </summary>
+		/// <remarks>
+		///     Defaults to character '='
+		/// </remarks>
+		public char KeyValueAssigmentChar { get; set; }
 
         /// <summary>
         ///     Sets the string around KeyValuesAssignmentChar

--- a/src/IniFileParser/Model/Formatting/DefaultIniDataFormatter.cs
+++ b/src/IniFileParser/Model/Formatting/DefaultIniDataFormatter.cs
@@ -65,13 +65,22 @@ namespace IniParser.Model.Formatting
             // Write blank line before section, but not if it is the first line
             if (sb.Length > 0) sb.AppendLine();
 
-            // Leading comments
-            WriteComments(section.LeadingComments, sb);
+			if (!Configuration.CommentsAfterLine)
+			{
+				// Leading comments before section
+				WriteComments(section.LeadingComments, sb);
+			}
 
             //Write section name
             sb.AppendLine(string.Format("{0}{1}{2}", Configuration.SectionStartChar, section.SectionName, Configuration.SectionEndChar));
 
-            WriteKeyValueData(section.Keys, sb);
+			if (Configuration.CommentsAfterLine)
+			{
+				// Leading comments after section
+				WriteComments(section.LeadingComments, sb);
+			}
+
+			WriteKeyValueData(section.Keys, sb);
 
             // Trailing comments
             WriteComments(section.TrailingComments, sb);
@@ -82,14 +91,23 @@ namespace IniParser.Model.Formatting
 
             foreach (KeyData keyData in keyDataCollection)
             {
-                // Add a blank line if the key value pair has comments
-                if (keyData.Comments.Count > 0) sb.AppendLine();
+                if (!Configuration.CommentsAfterLine)
+                {
+                    // Add a blank line if the key value pair has comments
+                    if (keyData.Comments.Count > 0) sb.AppendLine();
 
-                // Write key comments
-                WriteComments(keyData.Comments, sb);
+                    // Write key comments
+                    WriteComments(keyData.Comments, sb);
+                }
 
                 //Write key and value
                 sb.AppendLine(string.Format("{0}{3}{1}{3}{2}", keyData.KeyName, Configuration.KeyValueAssigmentChar, keyData.Value, Configuration.AssigmentSpacer));
+
+                if (Configuration.CommentsAfterLine)
+                {
+                    // Write key comments
+                    WriteComments(keyData.Comments, sb);
+                }
             }
         }
 

--- a/src/IniFileParser/Model/SectionData.cs
+++ b/src/IniFileParser/Model/SectionData.cs
@@ -98,6 +98,16 @@ namespace IniParser.Model
                 TrailingComments.Add(comment);
         }
 
+		/// <summary>
+		/// Sets the value of <see cref="_searchComparer"/>
+		/// </summary>
+		/// <param name="comparer">Value</param>
+		internal SectionData SetSearchComparer(IEqualityComparer<string> comparer)
+		{
+			_searchComparer = comparer;
+			return this;
+		}
+
 		#endregion
 
         #region Properties

--- a/src/IniFileParser/Model/SectionDataCollection.cs
+++ b/src/IniFileParser/Model/SectionDataCollection.cs
@@ -116,11 +116,11 @@ namespace IniParser.Model
         {
             if (ContainsSection(data.SectionName))
             {
-                SetSectionData(data.SectionName, new SectionData(data, _searchComparer));
+                SetSectionData(data.SectionName, data.SetSearchComparer(_searchComparer));
             }
             else
             {
-                _sectionData.Add(data.SectionName, new SectionData(data, _searchComparer));
+                _sectionData.Add(data.SectionName, data.SetSearchComparer(_searchComparer));
             }
         }
         /// <summary>


### PR DESCRIPTION
Hi Ricardo,
I really appreciate your library!
I would like to contribute with these three minor changes, if you like them:

1) **SectionDataCollection: Add uses directly the original instance of SectionData**
in this commit I let the SectionDataCollection add the original SectionData instance instead of creating a copy, so you can do something like:
```
SectionData newsection = new SectionData("Test");
newsection.LeadingComments.Add("comment 1");
iniData.Sections.Add(newsection);

```
Before the commit only the section name was preserved.
With this commit the comments are kept and added to the IniData collection.

2) **Added .editorconfig file to use with http://editorconfig.org/ visual studio extension**
In this commit I added the '.editorconfig' file to the project so, with the http://editorconfig.org/ visual studio extension, you can change editor configurations, like tab spaces, to be different among projects.
This because, in my Visual Studio editor settings, I use tab characters instead of spaces and it was difficult to edit the project files without messing all the tabulations.

3) **Added IniParserConfiguration.CommentsAfterLine flag to allow comments after the section or key value pair line**
This is the biggest change I made because I wanted this two behaviors:
a) the LeadingComments of a section after its declaration instead of before;
b) the comments of a key value pair after its declaration and without blank lines.

I then added the _IniParserConfiguration.CommentsAfterLine_ flag to accomplish this task, but, for now, I sacrified the TrailingComments of the section, because all the trailing comments are placed in the last key value pair.

I hope you like my edits, as a way to thank you for the great work!

Kind regards
Francesco