### PR TITLE
Allow setting the newline string used when writing a file

### DIFF
--- a/src/INIFileParser.Example/Program.cs
+++ b/src/INIFileParser.Example/Program.cs
@@ -50,7 +50,10 @@ namespace INIFileParser.Example
             //Save to a file
             Console.WriteLine("---- Saving the new ini file to the file NewTestIniFile.ini ----");
             Console.WriteLine();
-            
+
+            // Uncomment this to change the new line string used to write the ini file to disk to 
+            // force use the windows style new line
+            //modifiedParsedData.Configuration.NewLineStr = "\r\n";
             fileIniData.WriteFile("NewTestIniFile.ini", modifiedParsedData);
         }
 

--- a/src/IniFileParser.Tests/Unit/Configuration/ConfigurationTests.cs
+++ b/src/IniFileParser.Tests/Unit/Configuration/ConfigurationTests.cs
@@ -164,6 +164,19 @@ key # = wops!
         }
 
         [Test]
+        public void check_new_line_confige_on_ini_writing()
+        {
+            IniData data = new IniDataParser(new LiberalTestConfiguration()).Parse(iniFileStr);
+
+            data.Configuration.NewLineStr = "^_^";
+
+            Assert.That(
+                data.ToString().Replace("^_^", string.Empty), 
+                Is.EqualTo(iniFileStr.Replace(Environment.NewLine, string.Empty)));
+        }
+
+
+        [Test]
         public void escape_comment_regex_special_characters()
         {
             var iniStr = @"[Section]

--- a/src/IniFileParser/Model/Configuration/IniParserConfiguration.cs
+++ b/src/IniFileParser/Model/Configuration/IniParserConfiguration.cs
@@ -51,6 +51,7 @@ namespace IniParser.Model.Configuration
             SectionEndChar = ']';
             KeyValueAssigmentChar = '=';
             AssigmentSpacer = " ";
+            NewLineStr = Environment.NewLine;
             ConcatenateDuplicateKeys = false;
             AllowKeysWithoutSection = true;
             AllowDuplicateKeys = false;
@@ -167,6 +168,18 @@ namespace IniParser.Model.Configuration
             }
         }
 
+        /// <summary>
+        ///     Gets or sets the string to use as new line string when formating an IniData structure using a
+        ///     IIniDataFormatter. Parsing an ini-file accepts any new line character (Unix/windows)
+        /// </summary>
+        /// <remarks>
+        ///     This allows to write a file with unix new line characters on windows (and vice versa)
+        /// </remarks>
+        /// <value>Defaults to value Environment.NewLine</value>
+        public string NewLineStr
+        {
+            get; set;
+        }
         /// <summary>
         ///     Sets the char that defines a value assigned to a key
         /// </summary>

--- a/src/IniFileParser/Model/Formatting/DefaultIniDataFormatter.cs
+++ b/src/IniFileParser/Model/Formatting/DefaultIniDataFormatter.cs
@@ -63,13 +63,17 @@ namespace IniParser.Model.Formatting
         private void WriteSection(SectionData section, StringBuilder sb)
         {
             // Write blank line before section, but not if it is the first line
-            if (sb.Length > 0) sb.AppendLine();
+            if (sb.Length > 0) sb.Append(Configuration.NewLineStr);
 
             // Leading comments
             WriteComments(section.LeadingComments, sb);
 
             //Write section name
-            sb.AppendLine(string.Format("{0}{1}{2}", Configuration.SectionStartChar, section.SectionName, Configuration.SectionEndChar));
+            sb.Append(string.Format("{0}{1}{2}{3}", 
+                Configuration.SectionStartChar, 
+                section.SectionName, 
+                Configuration.SectionEndChar, 
+                Configuration.NewLineStr));
 
             WriteKeyValueData(section.Keys, sb);
 
@@ -83,20 +87,25 @@ namespace IniParser.Model.Formatting
             foreach (KeyData keyData in keyDataCollection)
             {
                 // Add a blank line if the key value pair has comments
-                if (keyData.Comments.Count > 0) sb.AppendLine();
+                if (keyData.Comments.Count > 0) sb.Append(Configuration.NewLineStr);
 
                 // Write key comments
                 WriteComments(keyData.Comments, sb);
 
                 //Write key and value
-                sb.AppendLine(string.Format("{0}{3}{1}{3}{2}", keyData.KeyName, Configuration.KeyValueAssigmentChar, keyData.Value, Configuration.AssigmentSpacer));
+                sb.Append(string.Format("{0}{3}{1}{3}{2}{4}", 
+                    keyData.KeyName,
+                    Configuration.KeyValueAssigmentChar, 
+                    keyData.Value, 
+                    Configuration.AssigmentSpacer, 
+                    Configuration.NewLineStr));
             }
         }
 
         private void WriteComments(List<string> comments, StringBuilder sb)
         {
             foreach (string comment in comments)
-                sb.AppendLine(string.Format("{0}{1}", Configuration.CommentString, comment));
+                sb.Append(string.Format("{0}{1}{2}", Configuration.CommentString, comment, Configuration.NewLineStr));
         }
         #endregion
         


### PR DESCRIPTION
As requested in issue #108 by @sergiorykov the poor soul (:wink:) that needs to create files with unix endlines on windows