### PR TITLE
When parsing a line with no key, just skip it instead of throwing

### DIFF
--- a/src/IniFileParser.Tests/Unit/Configuration/ConfigurationTests.cs
+++ b/src/IniFileParser.Tests/Unit/Configuration/ConfigurationTests.cs
@@ -67,12 +67,6 @@ this_is_not_a_comment = ;no comment
 name = Marble Zone
 ";
 
-        string iniFileReallyBad =
-@"
-{no section}
-key # = wops!
-= value
-";
         #endregion 
 
         [SetUp]
@@ -105,12 +99,6 @@ key # = wops!
         {
             Assert.That(_parser.Configuration, Is.InstanceOf(typeof (LiberalTestConfiguration)));
             Assert.That(_parser.Parse(iniFileStr).Configuration, Is.InstanceOf(typeof(LiberalTestConfiguration)));
-        }
-
-        [Test]
-        public void parser_really_bad_ini_format()
-        {
-            Assert.That(_parser.Parse(iniFileReallyBad), Is.Null);    
         }
 
         [Test]

--- a/src/IniFileParser.Tests/Unit/Parser/ParserTests.cs
+++ b/src/IniFileParser.Tests/Unit/Parser/ParserTests.cs
@@ -262,7 +262,8 @@ key1 = value1";
         {
             string data =
                 @"win] 
-key1 = value1";
+key1 = value1
+ = value2";
 
             var parser = new IniDataParser();
 
@@ -508,5 +509,7 @@ key2 = value2";
 			Assert.That(parsedData.Sections["W101 0.5\" wc"], Is.Not.Empty);
 			Assert.That(parsedData.Sections["W103 0.5' wc"], Is.Not.Empty);
 		}
+
+
     }
 }

--- a/src/IniFileParser/Model/Configuration/IniParserConfiguration.cs
+++ b/src/IniFileParser/Model/Configuration/IniParserConfiguration.cs
@@ -208,7 +208,7 @@ namespace IniParser.Model.Configuration
         ///     Defaults to <c>true</c>.
         /// </remarks>
         public bool AllowKeysWithoutSection { get; set; }
-
+			
         /// <summary>
         ///     If set to <c>false</c> and the <see cref="IniDataParser"/> finds duplicate keys in a
         ///     section the parser will stop with an error.

--- a/src/IniFileParser/Parser/IniDataParser.cs
+++ b/src/IniFileParser/Parser/IniDataParser.cs
@@ -344,6 +344,9 @@ namespace IniParser.Parser
         {
             // get key and value data
             string key = ExtractKey(line);
+
+			if (string.IsNullOrEmpty(key) && Configuration.SkipInvalidLines) return;
+
             string value = ExtractValue(line);
 
             // Check if we haven't read any section yet


### PR DESCRIPTION
fixes  #119