### PR TITLE
Add variable substitution support at IniData level

### DIFF
--- a/src/IniFileParser.Tests/INIFileParser.Tests.csproj
+++ b/src/IniFileParser.Tests/INIFileParser.Tests.csproj
@@ -83,6 +83,7 @@
       <Link>Properties\AssemblyInfo.cs</Link>
     </Compile>
     <Compile Include="Unit\Model\KeyDataCollectionTests.cs" />
+    <Compile Include="Unit\Parser\VariableParserTests.cs" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\IniFileParser\INIFileParser.csproj">

--- a/src/IniFileParser.Tests/Unit/Parser/VariableParserTests.cs
+++ b/src/IniFileParser.Tests/Unit/Parser/VariableParserTests.cs
@@ -1,0 +1,62 @@
+﻿using IniParser.Model;
+using IniParser.Parser;
+using NUnit.Framework;
+using IniParser.Exceptions;
+
+namespace IniFileParser.Tests
+{
+
+	[TestFixture]
+	public class ReferenceParserTests
+	{
+
+		string iniFileStr =
+	@";comment for section1
+[section1]
+
+;comment for key1
+key1 = value1
+key2 = ${section1.key1}
+
+[section2]
+
+;comment for myKey1
+mykey1 = ${section1.key1}
+mykey2 = ${section1.key2}
+";
+		
+		[Test]
+		public void parse_ini_string_with_variables()
+		{
+			var parser = new IniDataParser();
+			parser.Configuration.VariableSubstitution = true;
+			IniData data = parser.Parse(iniFileStr);
+
+			Assert.That(data, Is.Not.Null);
+			Assert.That(data.Sections.Count, Is.EqualTo(2));
+
+			var section1 = data.Sections.GetSectionData("section1");
+
+			Assert.That(section1, Is.Not.Null);
+			Assert.That(section1.SectionName, Is.EqualTo("section1"));
+			Assert.That(section1.Comments, Is.Not.Empty);
+			Assert.That(section1.Comments.Count, Is.EqualTo(1));
+
+			Assert.That(section1.Keys, Is.Not.Null);
+			Assert.That(section1.Keys.Count, Is.EqualTo(2));
+			Assert.That(data.GetKey("section1.key1"), Is.Not.Null);
+			Assert.That(data.GetKey("section1.key1"), Is.EqualTo("value1"));
+			Assert.That(data.GetKey("section1.key2"), Is.Not.Null);
+			Assert.That(data.GetKey("section1.key2"), Is.EqualTo("value1"));
+
+			var section2 = data.Sections.GetSectionData("section2");
+
+			Assert.That(data.GetKey("section2.mykey1"), Is.Not.Null);
+			Assert.That(data.GetKey("section2.mykey1"), Is.EqualTo("value1"));
+			Assert.That(data.GetKey("section2.mykey2"), Is.Not.Null);
+			Assert.That(data.GetKey("section2.mykey2"), Is.EqualTo("value1"));
+		}
+
+
+	}
+}

--- a/src/IniFileParser/Model/Configuration/IniParserConfiguration.cs
+++ b/src/IniFileParser/Model/Configuration/IniParserConfiguration.cs
@@ -59,6 +59,7 @@ namespace IniParser.Model.Configuration
             AllowCreateSectionsOnFly = true;
             ThrowExceptionsOnError = true;
             SkipInvalidLines = false;
+			VariableSubstitution = false;
         }
 
         /// <summary>
@@ -79,6 +80,7 @@ namespace IniParser.Model.Configuration
             SectionEndChar = ori.SectionEndChar;
             CommentString = ori.CommentString;
             ThrowExceptionsOnError = ori.ThrowExceptionsOnError;
+			VariableSubstitution = ori.VariableSubstitution;
 
           // Regex values should recreate themselves.
         }
@@ -276,6 +278,8 @@ namespace IniParser.Model.Configuration
         public bool AllowCreateSectionsOnFly { get; set; }
 
         public bool SkipInvalidLines { get; set; }
+
+		public bool VariableSubstitution { get; set; }
 
         #endregion
 

--- a/src/IniFileParser/Model/IniData.cs
+++ b/src/IniFileParser/Model/IniData.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Text.RegularExpressions;
 using IniParser.Model.Configuration;
 using IniParser.Model.Formatting;
 
@@ -235,7 +236,7 @@ namespace IniParser.Model
             if (!sectionData.ContainsKey(key))
                 return false;
 
-            value = sectionData[key];
+			value = this.Configuration.VariableSubstitution ? Substitute(sectionData[key]) : sectionData[key];
             return true;
         }
 
@@ -285,6 +286,16 @@ namespace IniParser.Model
             {
                 Global[globalValue.KeyName] = globalValue.Value;
             }
+		}
+
+		/// <summary>
+		/// Substitute variables with corresponding values
+		/// </summary>
+		/// <returns>The substituted string</returns>
+		/// <param name="value">Value.</param>
+		private string Substitute(string value)
+		{
+			return Regex.Replace(value, @"\$\{([^}]+)\}", m => GetKey(m.Groups[1].Value));
         }
     }
 }


### PR DESCRIPTION
- Allow automatic substitution of ${section.key} values with corresponding value
- Works only with IniData.GetKey
see src/IniFileParser.Tests/Unit/Parser/VariableParserTests.cs for usage details.
