### PR TITLE
Initial attempt at .NET Standard 1.3 support

### DIFF
--- a/src/IniFileParser/CompatibilityExtensions.cs
+++ b/src/IniFileParser/CompatibilityExtensions.cs
@@ -16,5 +16,23 @@ namespace IniParser
             return type.GetTypeInfo().DeclaredProperties.ToArray();
         }
 #endif
+        internal static Version GetCurrentVersion(this Type type)
+        {
+            Assembly assembly;
+#if NET20
+            assembly = Assembly.GetExecutingAssembly();
+#else
+            assembly = type.GetTypeInfo().Assembly;
+#endif
+            return assembly.GetName().Version;
+        }
     }
+}
+
+// you need this once (only), and it must be in this namespace
+namespace System.Runtime.CompilerServices
+{
+    [AttributeUsage(AttributeTargets.Assembly | AttributeTargets.Class
+         | AttributeTargets.Method)]
+    public sealed class ExtensionAttribute : Attribute { }
 }

--- a/src/IniFileParser/CompatibilityExtensions.cs
+++ b/src/IniFileParser/CompatibilityExtensions.cs
@@ -1,0 +1,20 @@
+﻿using System;
+using System.Collections.Generic;
+#if !NET20
+using System.Linq;
+#endif
+using System.Reflection;
+using System.Text;
+
+namespace IniParser
+{
+    internal static class CompatibilityExtensions
+    {
+#if !NET20
+        internal static PropertyInfo[] GetProperties(this Type type)
+        {
+            return type.GetTypeInfo().DeclaredProperties.ToArray();
+        }
+#endif
+    }
+}

--- a/src/IniFileParser/Exceptions/ParsingException.cs
+++ b/src/IniFileParser/Exceptions/ParsingException.cs
@@ -7,9 +7,7 @@ namespace IniParser.Exceptions
     /// </summary>
     public class ParsingException : Exception
     {
-#if NET20
         public Version LibVersion {get; private set;}
-#endif
         public int LineNumber {get; private set;}
         public string LineValue {get; private set;}
 
@@ -25,29 +23,16 @@ namespace IniParser.Exceptions
             :this(msg, lineNumber, lineValue, null)
         {}
 
-#if NET20
         public ParsingException(string msg, int lineNumber, string lineValue, Exception innerException)
             : base(
                 string.Format(
                     "{0} while parsing line number {1} with value \'{2}\' - IniParser version: {3}", 
-                    msg, lineNumber, lineValue, System.Reflection.Assembly.GetExecutingAssembly().GetName().Version),
+                    msg, lineNumber, lineValue, typeof(ParsingException).GetCurrentVersion()),
                 innerException) 
         { 
-            LibVersion = System.Reflection.Assembly.GetExecutingAssembly().GetName().Version;
+            LibVersion = typeof(ParsingException).GetCurrentVersion();
             LineNumber = lineNumber;
             LineValue = lineValue;
         }
-#else
-        public ParsingException(string msg, int lineNumber, string lineValue, Exception innerException)
-            : base(
-                string.Format(
-                    "{0} while parsing line number {1} with value \'{2}\'",
-                    msg, lineNumber, lineValue),
-                innerException)
-        {
-            LineNumber = lineNumber;
-            LineValue = lineValue;
-        }
-#endif
     }
 }

--- a/src/IniFileParser/Exceptions/ParsingException.cs
+++ b/src/IniFileParser/Exceptions/ParsingException.cs
@@ -7,7 +7,9 @@ namespace IniParser.Exceptions
     /// </summary>
     public class ParsingException : Exception
     {
+#if NET20
         public Version LibVersion {get; private set;}
+#endif
         public int LineNumber {get; private set;}
         public string LineValue {get; private set;}
 
@@ -22,7 +24,8 @@ namespace IniParser.Exceptions
         public ParsingException(string msg, int lineNumber, string lineValue)
             :this(msg, lineNumber, lineValue, null)
         {}
-            
+
+#if NET20
         public ParsingException(string msg, int lineNumber, string lineValue, Exception innerException)
             : base(
                 string.Format(
@@ -34,5 +37,17 @@ namespace IniParser.Exceptions
             LineNumber = lineNumber;
             LineValue = lineValue;
         }
+#else
+        public ParsingException(string msg, int lineNumber, string lineValue, Exception innerException)
+            : base(
+                string.Format(
+                    "{0} while parsing line number {1} with value \'{2}\'",
+                    msg, lineNumber, lineValue),
+                innerException)
+        {
+            LineNumber = lineNumber;
+            LineValue = lineValue;
+        }
+#endif
     }
 }

--- a/src/IniFileParser/INIFileParser.csproj
+++ b/src/IniFileParser/INIFileParser.csproj
@@ -1,116 +1,32 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
-<Project DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003" ToolsVersion="4.0">
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
   <PropertyGroup>
-    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
-    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
-    <ProductVersion>8.0.30703</ProductVersion>
-    <SchemaVersion>2.0</SchemaVersion>
-    <ProjectGuid>{5E46DCF4-C473-4171-9F9B-F3910B5EC407}</ProjectGuid>
-    <OutputType>Library</OutputType>
-    <AppDesignerFolder>Properties</AppDesignerFolder>
-    <RootNamespace>IniParser</RootNamespace>
-    <AssemblyName>INIFileParser</AssemblyName>
-    <SignAssembly>True</SignAssembly>
-    <AssemblyOriginatorKeyFile>Properties\publickey.snk</AssemblyOriginatorKeyFile>
-    <FileUpgradeFlags>
-    </FileUpgradeFlags>
-    <UpgradeBackupLocation>
-    </UpgradeBackupLocation>
-    <OldToolsVersion>3.5</OldToolsVersion>
-    <TargetFrameworkVersion>v2.0</TargetFrameworkVersion>
-    <PublishUrl>publish\</PublishUrl>
-    <Install>true</Install>
-    <InstallFrom>Disk</InstallFrom>
-    <UpdateEnabled>false</UpdateEnabled>
-    <UpdateMode>Foreground</UpdateMode>
-    <UpdateInterval>7</UpdateInterval>
-    <UpdateIntervalUnits>Days</UpdateIntervalUnits>
-    <UpdatePeriodically>false</UpdatePeriodically>
-    <UpdateRequired>false</UpdateRequired>
-    <MapFileExtensions>true</MapFileExtensions>
-    <ApplicationRevision>0</ApplicationRevision>
-    <ApplicationVersion>1.0.0.%2a</ApplicationVersion>
-    <IsWebBootstrapper>false</IsWebBootstrapper>
-    <UseApplicationTrust>false</UseApplicationTrust>
-    <BootstrapperEnabled>true</BootstrapperEnabled>
-    <ReleaseVersion>
-    </ReleaseVersion>
+    <TargetFrameworks>net20;netstandard1.3</TargetFrameworks>
+    <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
+    <AssemblyOriginatorKeyFile>Properties/publickey.snk</AssemblyOriginatorKeyFile>
+    <SignAssembly>true</SignAssembly>
+    <PublicSign Condition="'$(OS)' != 'Windows_NT'">true</PublicSign>
   </PropertyGroup>
-  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
-    <DebugSymbols>True</DebugSymbols>
-    <DebugType>full</DebugType>
-    <Optimize>False</Optimize>
-    <OutputPath>bin\Debug\</OutputPath>
-    <DefineConstants>DEBUG;TRACE</DefineConstants>
-    <ErrorReport>prompt</ErrorReport>
-    <WarningLevel>4</WarningLevel>
-    <CodeAnalysisRuleSet>AllRules.ruleset</CodeAnalysisRuleSet>
+  <PropertyGroup>
+    <PackageId>ini-parser</PackageId>
+    <PackageVersion>1.0</PackageVersion>
+    <Title>INI Parser</Title>
+    <Authors>Ricardo Amores Hernández</Authors>
+    <PackageLicenseUrl>https://github.com/rickyah/ini-parser/blob/master/LICENSE</PackageLicenseUrl>
+    <PackageProjectUrl>https://github.com/rickyah/ini-parser</PackageProjectUrl>
+    <PackageTags>ini</PackageTags>
+    <Description>A .NET, Mono and Unity3d compatible(*) library for reading/writing INI data from IO streams, file streams, and strings written in C#.
+
+Also implements merging operations, both for complete ini files, sections, or even just a subset of the keys contained by the files.
+
+(*) This library is 100% .NET code and does not have any dependencies on Windows API calls in order to be portable.</Description>
+    <RootNamespace>IniParser</RootNamespace>
+  <!-- <NuspecFile>./INIFileParser.nuspec</NuspecFile> --> <!-- as an alternative to using the above properties -->
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
-    <DebugType>pdbonly</DebugType>
     <Optimize>True</Optimize>
     <OutputPath>..\..\lib\</OutputPath>
-    <DefineConstants>TRACE</DefineConstants>
-    <ErrorReport>prompt</ErrorReport>
-    <WarningLevel>4</WarningLevel>
     <DocumentationFile>..\..\lib\INIFileParser.xml</DocumentationFile>
     <CodeAnalysisRuleSet>AllRules.ruleset</CodeAnalysisRuleSet>
-    <DebugSymbols>true</DebugSymbols>
   </PropertyGroup>
-  <ItemGroup>
-    <Reference Include="System" />
-    <Reference Include="System.Data" />
-    <Reference Include="System.Xml" />
-  </ItemGroup>
-  <ItemGroup>
-    <Compile Include="Helpers\Assert.cs" />
-    <Compile Include="FileIniParser.cs" />
-    <Compile Include="Model\IniData.cs" />
-    <Compile Include="Model\KeyData.cs" />
-    <Compile Include="Model\KeyDataCollection.cs" />
-    <Compile Include="Parser\IniDataParser.cs" />
-    <Compile Include="Model\SectionData.cs" />
-    <Compile Include="Model\SectionDataCollection.cs" />
-    <Compile Include="StreamIniDataParser.cs" />
-    <Compile Include="StringIniParser.cs" />
-    <Compile Include="Exceptions\ParsingException.cs" />
-    <Compile Include="Model\Formatting\DefaultIniDataFormatter.cs" />
-    <Compile Include="Model\Formatting\IIniDataFormatter.cs" />
-    <Compile Include="Model\IniDataCaseInsensitive.cs" />
-    <Compile Include="Properties\AssemblyInfo.cs" />
-    <Compile Include="Parser\ConcatenateDuplicatedKeysIniDataParser.cs" />
-    <Compile Include="Model\Configuration\IniParserConfiguration.cs" />
-    <Compile Include="Model\Configuration\ConcatenateDuplicatedKeysIniParserConfiguration.cs" />
-  </ItemGroup>
-  <ItemGroup>
-    <None Include="INIFileParser.nuspec" />
-    <None Include="Properties\publickey.snk" />
-  </ItemGroup>
-  <ItemGroup>
-    <BootstrapperPackage Include="Microsoft.Net.Client.3.5">
-      <Visible>False</Visible>
-      <ProductName>.NET Framework 3.5 SP1 Client Profile</ProductName>
-      <Install>false</Install>
-    </BootstrapperPackage>
-    <BootstrapperPackage Include="Microsoft.Net.Framework.3.5.SP1">
-      <Visible>False</Visible>
-      <ProductName>.NET Framework 3.5 SP1</ProductName>
-      <Install>true</Install>
-    </BootstrapperPackage>
-    <BootstrapperPackage Include="Microsoft.Windows.Installer.3.1">
-      <Visible>False</Visible>
-      <ProductName>Windows Installer 3.1</ProductName>
-      <Install>true</Install>
-    </BootstrapperPackage>
-  </ItemGroup>
-  <ItemGroup />
-  <Import Project="$(MSBuildBinPath)\Microsoft.CSharp.targets" />
-  <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
-       Other similar extension points exist, see Microsoft.Common.targets.
-  <Target Name="BeforeBuild">
-  </Target>
-  <Target Name="AfterBuild">
-  </Target>
-  -->
-  <ItemGroup />
 </Project>

--- a/src/IniFileParser/Model/ICloneable.cs
+++ b/src/IniFileParser/Model/ICloneable.cs
@@ -1,0 +1,11 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace IniParser.Model
+{
+    internal interface ICloneable
+    {
+        object Clone();
+    }
+}


### PR DESCRIPTION
This resolves #122 . It uses the same technique as #144 for avoiding `ICloneable` while also resolving some of the reflection issues, *theoretically* allowing for support for both .NET 2.0 and .NET Standard 1.3 (the lowest that supports everything used in this codebase).

Note that this is based on the `development` branch, while I notice that #144 uses the `v3.0/*` branches. I don't know what the timeline is for 3.0, but this adds support for it in the current codebase in a way that should be pretty easy to integrate into 3.0.

Note that I haven't done much work with pre-4.0 .NET Framework, so I skipped over large chunks of the `csproj` that might actually be needed 😖 

Let me know if it needs changes, or if you have questions, happy to update 😄 