### PR TITLE
Fix typo and broken test

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,6 +102,6 @@ You can easily use this library in your Unity3D projects. Just drop either the c
 
 ini-parser is actually being used in [ProjectPrefs](http://u3d.as/content/garrafote/project-prefs/5so) a free add-on available in the Unity Assets Store that allows you to set custom preferences for your project. I'm not affiliated with this project: Kudos to Garrafote for making this add-on.
 
-## Contributing
+## Contributing
 
 Do you have an idea to improve this library, or did you happen to run into a bug? Please share your idea or the bug you found in the [issues page](https://github.com/rickyah/ini-parser/issues), or even better: feel free to fork and [contribute](https://github.com/rickyah/ini-parser/wiki/Contributing) to this project with a Pull Request.

--- a/src/INIFileParser.Example/Program.cs
+++ b/src/INIFileParser.Example/Program.cs
@@ -59,7 +59,7 @@ namespace IniParser.Example
         {
             modifiedParsedData["GeneralConfiguration"]["setMaxErrors"] = "10";
             modifiedParsedData.Sections.AddSection("newSection");
-            modifiedParsedData.Sections.GetSectionData("newSection").LeadingComments
+            modifiedParsedData.Sections.GetSectionData("newSection").Comments
                 .Add("This is a new comment for the section");
             modifiedParsedData.Sections.GetSectionData("newSection").Keys.AddKey("myNewKey", "value");
             modifiedParsedData.Sections.GetSectionData("newSection").Keys.GetKeyData("myNewKey").Comments

--- a/src/IniFileParser.Tests/Unit/Model/INIDataTests.cs
+++ b/src/IniFileParser.Tests/Unit/Model/INIDataTests.cs
@@ -1,4 +1,6 @@
 ﻿using System;
+using NUnit.Framework;
+using IniParser.Parser;
 using IniParser.Model;
 using IniParser.Model.Configuration;
 


### PR DESCRIPTION
 - Fix typo in README file.
    - The 'Contribution' section didn't be displayed properly.
 - Usage of obsolete property
    - In the example code, there is a place that uses 'LeadingComments', not 'Comments'.
 - Fix broken tests for data.
    - In the 'INIDataTests', the project cannot be built because there are no 'using' statements.