### PR TITLE
Fix incorrect comment extracting and failing test

### DIFF
--- a/src/IniFileParser.Tests/Unit/Parser/ParserTests.cs
+++ b/src/IniFileParser.Tests/Unit/Parser/ParserTests.cs
@@ -4,6 +4,7 @@ using IniParser.Parser;
 using NUnit.Framework;
 using IniParser.Exceptions;
 using IniParser.Model.Configuration;
+using IniParser.Model.Formatting;
 
 namespace IniFileParser.Tests.Unit.Parser
 {
@@ -539,6 +540,21 @@ key2 = value2";
 
             Assert.That(parsedData.Sections["W101 0.5\" wc"], Is.Not.Empty);
             Assert.That(parsedData.Sections["W103 0.5' wc"], Is.Not.Empty);
+        }
+
+        [Test, Description("Test for Issue 167: https://github.com/rickyah/ini-parser/issues/167")]
+        public void check_extract_comments_correctly()
+        {
+            var parser = new IniDataParser();
+            var iniDataString = @"[Section1]
+
+## Data Commentary
+data = value;
+";
+            parser.Scheme.CommentString = "##";
+            var parsedData = parser.Parse(iniDataString);
+
+            Assert.That(parsedData.ToString(), Is.EqualTo(iniDataString));
         }
     }
 }

--- a/src/IniFileParser.Tests/Unit/Parser/StringReaderBufferTest.cs
+++ b/src/IniFileParser.Tests/Unit/Parser/StringReaderBufferTest.cs
@@ -1,6 +1,7 @@
 ﻿using NUnit.Framework;
 using IniParser.Parser;
 using System.IO;
+using System;
 
 namespace IniFileParser.Tests
 {
@@ -71,7 +72,7 @@ namespace IniFileParser.Tests
             var str = InitBufferAndReadLine(@"   hello world!
 ");
 
-            Assert.That(buffer.Count, Is.EqualTo(str.Length -1 ));
+            Assert.That(buffer.Count, Is.EqualTo(str.Length - Environment.NewLine.Length));
             buffer.Trim();
             Assert.That(buffer.Count, Is.EqualTo(str.Trim().Length));
             Assert.That(buffer.ToString(), Is.EqualTo("hello world!"));

--- a/src/IniFileParser/Parser/IniDataParser.cs
+++ b/src/IniFileParser/Parser/IniDataParser.cs
@@ -277,7 +277,7 @@ namespace IniParser.Parser
             if (commentRange.IsEmpty) return false;
 
             var startIdx = commentRange.start + Scheme.CommentString.Length;
-            var endIdx = currentLine.Count - Scheme.CommentString.Length;
+            var endIdx = currentLine.Count - 1;
             var commentStr = currentLine.Substring(Range.WithIndexes(startIdx, endIdx));
 
             _currentCommentListTemp.Add(commentStr);


### PR DESCRIPTION
Hello!
This PR fixes the incorrect comment extracting when the comment string is more than one char.
(Related to issue #167.)

For example, if the following ini string exists:
(Assume that the comment string is '##')

```ini
[Section1]

## Data Commentary
data = value;

```
When it is converted to string, the result is the following string:
```ini
[Section1]

## Data Commentar
data = value;

```

The last character of comment is missing.
I think the end index in the extracting process should not be (count - comment string length), just (count  - 1) is enough.

I added a test for this example case in the 'ParserTests'.

By the way, there is a failing test in the 'StringReaderBufferTest'.
Because a new line character has length 2 in Windows, the 'check_trimming_with_new_line' test might fail.

This PR also fixes this.