### PR TITLE
Addressed a  compiler error, changes the project icon url to use embedded icon, and added additional target framework

### DIFF
--- a/src/IniParser.Example/IniParser.Example.csproj
+++ b/src/IniParser.Example/IniParser.Example.csproj
@@ -8,7 +8,7 @@
 
   <!-- Auto-select supported target frameworks based on MSBuild version -->
   <PropertyGroup Condition="'$(MSBuildRuntimeType)'=='Core'">
-    <TargetFrameworks>netcoreapp2.0</TargetFrameworks>
+    <TargetFrameworks>netcoreapp2.0;netcoreapp3.1</TargetFrameworks>
   </PropertyGroup>
     <PropertyGroup Condition="'$(MSBuildRuntimeType)'!='Core'">
     <TargetFrameworks>net461;netcoreapp2.0</TargetFrameworks>

--- a/src/IniParser.Tests/IniParser.Tests.csproj
+++ b/src/IniParser.Tests/IniParser.Tests.csproj
@@ -8,10 +8,10 @@
 
   <!-- Auto-select supported target frameworks based on MSBuild version -->
   <PropertyGroup Condition="'$(MSBuildRuntimeType)'=='Core'">
-    <TargetFrameworks>netcoreapp2.0</TargetFrameworks>
+    <TargetFrameworks>netcoreapp2.0;netcoreapp3.1</TargetFrameworks>
   </PropertyGroup>
     <PropertyGroup Condition="'$(MSBuildRuntimeType)'!='Core'">
-    <TargetFrameworks>net461;netcoreapp2.0</TargetFrameworks>
+    <TargetFrameworks>net461;netcoreapp2.0;netcoreapp3.1</TargetFrameworks>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/IniParser/IniDataParser.cs
+++ b/src/IniParser/IniDataParser.cs
@@ -246,7 +246,7 @@ namespace IniParser
             // the comment delimiter
             var startIdx = commentRange.start + Scheme.CommentString.Length;
             var size = currentLineTrimmed.Count - Scheme.CommentString.Length;
-            var range = Range.FromIndexWithSize(startIdx, size);
+            var range = IniParser.Parser.StringBuffer.Range.FromIndexWithSize(startIdx, size);
 
             var comment = currentLineTrimmed.Substring(range);
             if (Configuration.TrimComments)
@@ -345,10 +345,10 @@ namespace IniParser
 
             if (propertyAssigmentIdx.IsEmpty) return false;
 
-            var keyRange = Range.WithIndexes(0, propertyAssigmentIdx.start - 1);
+            var keyRange = IniParser.Parser.StringBuffer.Range.WithIndexes(0, propertyAssigmentIdx.start - 1);
             var valueStartIdx = propertyAssigmentIdx.end + 1;
             var valueSize = currentLine.Count - propertyAssigmentIdx.end - 1;
-            var valueRange = Range.FromIndexWithSize(valueStartIdx, valueSize);
+            var valueRange = IniParser.Parser.StringBuffer.Range.FromIndexWithSize(valueStartIdx, valueSize);
 
             var key = currentLine.Substring(keyRange);
             var value = currentLine.Substring(valueRange);

--- a/src/IniParser/IniParser.csproj
+++ b/src/IniParser/IniParser.csproj
@@ -11,7 +11,7 @@ Also implements merging operations, both for complete ini files, sections, or ev
 		<Authors>Ricardo Amores Hernández</Authors>
 		<PackageProjectUrl>https://github.com/rickyah/ini-parser</PackageProjectUrl>
 		<PackageLicenseExpression>MIT</PackageLicenseExpression>
-		<PackageIconUrl>https://raw.githubusercontent.com/rickyah/ini-parser/development/nuget-ini-icon.png</PackageIconUrl>
+		<PackageIconUrl>../../nuget-ini-icon.png</PackageIconUrl>
 		<Version>3.0</Version>
 		<SignAssembly>True</SignAssembly>
 		<AssemblyOriginatorKeyFile>Properties\publickey.snk</AssemblyOriginatorKeyFile>
@@ -27,12 +27,12 @@ Also implements merging operations, both for complete ini files, sections, or ev
 
 	<!-- Auto-select supported target frameworks based on MSBuild version -->
 	<PropertyGroup>
-		<TargetFrameworks>netstandard2.0</TargetFrameworks>
+		<TargetFrameworks>netstandard2.0;netcoreapp3.1</TargetFrameworks>
 		<RepositoryUrl>https://github.com/rickyah/ini-parser</RepositoryUrl>
 		<Copyright>Ricardo Amores Hernández 2009-2019</Copyright>
 	</PropertyGroup>
     <!-- Only generate NuGet package for full builds -->
-    <PropertyGroup Condition="'$(MSBuildRuntimeType)'=='Full'">
+    <PropertyGroup>
         <GeneratePackageOnBuild>True</GeneratePackageOnBuild>
     </PropertyGroup>
 </Project>


### PR DESCRIPTION
Added target framework for .netcoreapp3.1
Fixed a compiler error caused by an ambiguous reference
Switched over to using embedded icon (projectIconUrl is deprecated)
Changed IniParser.csproj to always generate package