### PR TITLE
Spell check source code and correct typo in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,7 +104,7 @@ comments are written before the element they refer to.
 To query, add or remove comments, access the property `Comments` available both in `SectionData` and `KeyData` models.
 
 ```csharp
-var listOfCommentsForSection = config.["user_settings"].Comments;
+var listOfCommentsForSection = config["user_settings"].Comments;
 var listOfCommentsForKey = config["user_settings"].GetKeyData("resolution").Comments;
 ```
 

--- a/src/IniParser.Example/Program.cs
+++ b/src/IniParser.Example/Program.cs
@@ -13,7 +13,7 @@ namespace IniParser.Example
 #Update rate in msecs
 setUpdate = 100
 
-#Maximun errors before quit
+#Maximum errors before quit
 setMaxErrors = 2
 
 #Users allowed to access the system

--- a/src/IniParser.Example/TestIniFile.ini
+++ b/src/IniParser.Example/TestIniFile.ini
@@ -4,7 +4,7 @@
 #Update rate in msecs
 setUpdate = 100
 
-#Maximun errors before quit
+#Maximum errors before quit
 setMaxErrors = 2
 
 #Users allowed to access the system

--- a/src/IniParser.Tests/Unit/Model/SectionCollectionTests.cs
+++ b/src/IniParser.Tests/Unit/Model/SectionCollectionTests.cs
@@ -20,7 +20,7 @@ namespace IniParser.Tests.Unit.Model
             SectionCollection sdc = new SectionCollection();
             Assert.That(sdc, Is.Empty);
 
-            //Add sectoin
+            //Add section
             sdc.Add(strSectionTest);
             sdc.Add(strSectionTest);
             Assert.That(sdc.Count, Is.EqualTo(1));
@@ -31,7 +31,7 @@ namespace IniParser.Tests.Unit.Model
             Assert.That(sdc.FindByName(strSectionTest).Comments, Is.Empty);
             Assert.That(sdc.FindByName(strSectionTest).Properties.Count, Is.EqualTo(0));
 
-            //Check add coments
+            //Check add comments
             sdc.FindByName(strSectionTest).Comments.Add(strComment);
             Assert.That(sdc.FindByName(strSectionTest).Comments.Count, Is.EqualTo(1));
             sdc.FindByName(strSectionTest).Comments.Clear();

--- a/src/IniParser.Tests/Unit/Parser/ParserTests.cs
+++ b/src/IniParser.Tests/Unit/Parser/ParserTests.cs
@@ -226,7 +226,7 @@ key = value";
         public void allow_whitespace_in_section_names()
         {
             string data =
-                @"[Web Colaboration]
+                @"[Web Collaboration]
 key = value";
 
             var parser = new IniDataParser();
@@ -234,9 +234,9 @@ key = value";
             IniData iniData = parser.Parse(data);
 
             Assert.That(iniData.Sections.Count, Is.EqualTo(1));
-            Assert.That(iniData.Sections.Contains("Web Colaboration"), Is.True);
-            Assert.That(iniData.Sections["Web Colaboration"].Contains("key"), Is.True);
-            Assert.That(iniData.Sections["Web Colaboration"]["key"], Is.EqualTo("value"));
+            Assert.That(iniData.Sections.Contains("Web Collaboration"), Is.True);
+            Assert.That(iniData.Sections["Web Collaboration"].Contains("key"), Is.True);
+            Assert.That(iniData.Sections["Web Collaboration"]["key"], Is.EqualTo("value"));
         }
 
         [Test]

--- a/src/IniParser/Configuration/IniParserConfiguration.cs
+++ b/src/IniParser/Configuration/IniParserConfiguration.cs
@@ -8,9 +8,9 @@ namespace IniParser.Configuration
     ///     With a configuration object you can redefine how the parser
     ///     will detect special items in the ini file by defining new regex
     ///     (e.g. you can redefine the comment regex so it just treat text as
-    ///     a comment iff the comment caracter is the first in the line)
+    ///     a comment iff the comment character is the first in the line)
     ///     or changing the set of characters used to define elements in
-    ///     the ini file (e.g. change the 'comment' caracter from ';' to '#')
+    ///     the ini file (e.g. change the 'comment' character from ';' to '#')
     ///     You can also define how the parser should treat errors, or how liberal
     ///     or conservative should it be when parsing files with "strange" formats.
     public class IniParserConfiguration : IDeepCloneable<IniParserConfiguration>
@@ -51,7 +51,7 @@ namespace IniParser.Configuration
         public bool CaseInsensitive { get; set; } = false;
 
         /// <summary>
-        ///     Allows having keys at the begining of the file, before any section 
+        ///     Allows having keys at the beginning of the file, before any section 
         ///     is defined. Those keys  don't belong to any section and are stored in 
         ///     the <see cref="IniData.Global"/> special field.
         ///     If set to false and the ini file contains keys outside a section,

--- a/src/IniParser/Configuration/IniScheme.cs
+++ b/src/IniParser/Configuration/IniScheme.cs
@@ -13,7 +13,7 @@ namespace IniParser.Configuration
         ///     Ctor.
         /// </summary>
         /// <remarks>
-        ///     By default the various delimiters for the data are setted:
+        ///     By default the various delimiters for the data are set:
         ///     <para>';' for one-line comments</para>
         ///     <para>'[' ']' for delimiting a section</para>
         ///     <para>'=' for linking key / value pairs</para>
@@ -51,7 +51,7 @@ namespace IniParser.Configuration
 
         /// <summary>
         ///     Sets the string that defines the start of a comment.
-        ///     A comment spans from the mirst matching comment string
+        ///     A comment spans from the first matching comment string
         ///     to the end of the line.
         /// </summary>
         /// <remarks>
@@ -93,7 +93,7 @@ namespace IniParser.Configuration
 
 
         /// <summary>
-        ///     Sets the string used in the ini file to denote a key / value assigment
+        ///     Sets the string used in the ini file to denote a key / value assignment
         /// </summary>
         /// <remarks>
         ///     Defaults to character '='

--- a/src/IniParser/Exceptions/ParsingException.cs
+++ b/src/IniParser/Exceptions/ParsingException.cs
@@ -3,7 +3,7 @@ using System;
 namespace IniParser.Exceptions
 {
     /// <summary>
-    /// Represents an error ococcurred while parsing data 
+    /// Represents an error occurred while parsing data 
     /// </summary>
     public class ParsingException : Exception
     {

--- a/src/IniParser/IniData.cs
+++ b/src/IniParser/IniData.cs
@@ -21,7 +21,7 @@ namespace IniParser
         }
         
         /// <summary>
-        ///     Initialzes an IniData instance with a given scheme
+        ///     Initializes an IniData instance with a given scheme
         /// </summary>
         /// <param name="scheme"></param>
         public IniData(IniScheme scheme)
@@ -40,7 +40,7 @@ namespace IniParser
 
         /// <summary>
         ///     If set to true, it will automatically create a section when you use the indexed 
-        ///     access with a section name that does not exis.
+        ///     access with a section name that does not exist.
         ///     If set to false, it will throw an exception if you try to access a section that 
         ///     does not exist with the index operator.
         /// </summary>

--- a/src/IniParser/IniDataParser.cs
+++ b/src/IniParser/IniDataParser.cs
@@ -11,9 +11,9 @@ using static IniParser.Parser.StringBuffer;
 namespace IniParser
 {
     /// <summary>
-	/// 	Responsible for parsing an string from an ini file, and creating
-	/// 	an <see cref="IniData"/> structure.
-	/// </summary>
+    ///     Responsible for parsing an string from an ini file, and creating
+    ///     an <see cref="IniData"/> structure.
+    /// </summary>
     public partial class IniDataParser
     {
         #region Initialization
@@ -73,10 +73,10 @@ namespace IniParser
         ///     Parses a string containing valid ini data
         /// </summary>
         /// <param name="textReader">
-        ///     Text reader for the source string contaninig the ini data
+        ///     Text reader for the source string containing the ini data
         /// </param>
         /// <returns>
-        ///     An <see cref="IniData"/> instance containing the data readed
+        ///     An <see cref="IniData"/> instance containing the data read
         ///     from the source
         /// </returns>
         /// <exception cref="ParsingException">
@@ -97,10 +97,10 @@ namespace IniParser
         ///     Parses a string containing valid ini data
         /// </summary>
         /// <param name="textReader">
-        ///     Text reader for the source string contaninig the ini data
+        ///     Text reader for the source string containing the ini data
         /// </param>
         /// <returns>
-        ///     An <see cref="IniData"/> instance containing the data readed
+        ///     An <see cref="IniData"/> instance containing the data read
         ///     from the source
         /// </returns>
         /// <exception cref="ParsingException">
@@ -142,7 +142,7 @@ namespace IniParser
             // TODO: is this try necessary?
             try
             {
-                // Orphan comments, assing to last section/key value
+                // Orphan comments, assign to last section/key value
                 if (Configuration.ParseComments && CurrentCommentListTemp.Count > 0)
                 {
                     if (iniData.Sections.Count > 0)
@@ -242,7 +242,7 @@ namespace IniParser
             currentLineTrimmed.TrimEnd();
 
             var commentRange = currentLineTrimmed.FindSubstring(Scheme.CommentString);
-            // Exctract the range of the string that contains the comment but not
+            // Extract the range of the string that contains the comment but not
             // the comment delimiter
             var startIdx = commentRange.start + Scheme.CommentString.Length;
             var size = currentLineTrimmed.Count - Scheme.CommentString.Length;
@@ -260,7 +260,7 @@ namespace IniParser
         }
 
         /// <summary>
-        ///     Proccess a string which contains an ini section.%
+        ///     Process a string which contains an ini section.%
         /// </summary>
         /// <param name="currentLine">
         ///     The string to be processed
@@ -482,7 +482,7 @@ namespace IniParser
         #region Fields
         uint _currentLineNumber;
 
-        // Holds a list of the exceptions catched while parsing
+        // Holds a list of the exceptions caught while parsing
         readonly List<Exception> _errorExceptions;
 
         // Temp list of comments
@@ -505,7 +505,7 @@ namespace IniParser
         }
         List<string> _currentCommentListTemp;
 
-        // Tmp var with the name of the seccion which is being process
+        // Temporary var with the name of the section which is being process
         string _currentSectionNameTemp;
 
         // Buffer used to hold the current line being processed.

--- a/src/IniParser/Model/IDeepCloneable.cs
+++ b/src/IniParser/Model/IDeepCloneable.cs
@@ -5,7 +5,7 @@
     ///  copied too instead of copying the reference.
     /// </summary>
     /// <typeparam name="T"></typeparam>
-    public interface IDeepCloneable<T> where T : class                                             
+    public interface IDeepCloneable<T> where T : class
     {
         T DeepClone();
     }

--- a/src/IniParser/Model/Property.cs
+++ b/src/IniParser/Model/Property.cs
@@ -48,7 +48,7 @@ namespace IniParser.Model
 
         /// <summary>
         /// Gets or sets the comment list associated to this property.
-        /// Makes a copy og the values when set
+        /// Makes a copy of the values when set
         /// </summary>
         public List<string> Comments
         {

--- a/src/IniParser/Model/PropertyCollection.cs
+++ b/src/IniParser/Model/PropertyCollection.cs
@@ -64,7 +64,7 @@ namespace IniParser.Model
         /// </summary>
         /// <remarks>
         ///     If we try to assign the value of a property which doesn't exists,
-        ///     a new one is added with the kay and the value specified
+        ///     a new one is added with the key and the value specified
         /// </remarks>
         /// <param name="keyName">
         ///     key of the property
@@ -182,7 +182,7 @@ namespace IniParser.Model
         ///     Key name to search
         /// </param>
         /// <returns>
-        ///     true if a property with the givne exists in the collectoin
+        ///     true if a property with the given exists in the collection
         ///     false otherwise
         /// </returns>
         public bool Contains(string keyName)
@@ -248,7 +248,7 @@ namespace IniParser.Model
         #region IEnumerable<KeyData> Members
 
         /// <summary>
-        /// Allows iteration througt the collection.
+        /// Allows iteration through the collection.
         /// </summary>
         /// <returns>A strong-typed IEnumerator </returns>
         public IEnumerator<Property> GetEnumerator()


### PR DESCRIPTION
This PR is simply correcting spelling errors.  It also corrects an error in an
example in the README file