### PR TITLE
Add more support for whitespace configuration

### DIFF
--- a/src/IniParser.Tests/Integration/ConfigurationOptionTests.cs
+++ b/src/IniParser.Tests/Integration/ConfigurationOptionTests.cs
@@ -157,7 +157,7 @@ data2 = 2";
         }
 
         [Test]
-        public void check_trim_properties()
+        public void check_trim_properties_and_values()
         {
             var ini = @"prop1=0
    prop2 =   value2  
@@ -172,6 +172,7 @@ data2 = 2";
             Assert.That(iniData.Global["prop2"], Is.EqualTo("value2"));
 
             parser.Configuration.TrimProperties = false;
+            parser.Configuration.TrimValues = false;
             iniData = parser.Parse(ini);
 
             Assert.That(iniData.Global.Contains("prop1"), Is.True);

--- a/src/IniParser.Tests/Integration/SchemeOptionTests.cs
+++ b/src/IniParser.Tests/Integration/SchemeOptionTests.cs
@@ -106,6 +106,8 @@ key1=1";
             var ini2 = @"key1 <== 1";
             parser.Scheme.PropertyAssigmentString = "<==";
             iniData = parser.Parse(ini2);
+
+            Assert.That(iniData.Global["key1"], Is.EqualTo("1"));
         }
     }
 }

--- a/src/IniParser.Tests/Unit/Parser/ParserTests.cs
+++ b/src/IniParser.Tests/Unit/Parser/ParserTests.cs
@@ -502,5 +502,43 @@ key2 = value2";
 			Assert.That(parsedData.Sections["W101 0.5\" wc"], Is.Not.Empty);
 			Assert.That(parsedData.Sections["W103 0.5' wc"], Is.Not.Empty);
 		}
+
+        [Test, Description("Allow leading spaces in property values")]
+        public void can_preserve_leading_space_in_value()
+        {
+            var parser = new IniDataParser();
+            parser.Configuration.TrimValues = false;
+            parser.Scheme.PropertyAssigmentString = " = ";
+
+            var iniDataString = @"[Section 1]
+key1 =  value1
+key2 = value2
+key3 = value3 ";
+            IniData parsedData = parser.Parse(iniDataString);
+
+            Assert.That(parsedData.Sections["Section 1"]["key1"], Is.EqualTo(" value1"));
+            Assert.That(parsedData.Sections["Section 1"]["key2"], Is.EqualTo("value2"));
+            Assert.That(parsedData.Sections["Section 1"]["key3"], Is.EqualTo("value3 "));
+        }
+
+        [Test, Description("Allow leading and railing space in the assignment string. Useful for reading properties with trailing space and values with leading space")]
+        public void allow_leading_and_trailing_space_in_assignment_string()
+        {
+            var parser = new IniDataParser();
+            parser.Scheme.PropertyAssigmentString = " = ";
+            parser.Configuration.TrimValues = false;
+            parser.Configuration.TrimProperties = false;
+
+            var iniDataString = @"[Section 1]
+key1 = value1
+key2  =  value2
+key3 = value3";
+            IniData parsedData = parser.Parse(iniDataString);
+
+            Assert.That(parsedData.Sections["Section 1"]["key1"], Is.EqualTo("value1"));
+            Assert.That(parsedData.Sections["Section 1"]["key2 "], Is.EqualTo(" value2"));
+            Assert.That(parsedData.Sections["Section 1"]["key3"], Is.EqualTo("value3"));
+            Assert.That(parsedData.Sections["Section 1"]["key2"], Is.Null);
+        }
     }
 }

--- a/src/IniParser/Configuration/IniParserConfiguration.cs
+++ b/src/IniParser/Configuration/IniParserConfiguration.cs
@@ -39,6 +39,7 @@ namespace IniParser.Configuration
             SkipInvalidLines = ori.SkipInvalidLines;
             TrimSections = ori.TrimSections;
             TrimProperties = ori.TrimProperties;
+            TrimValues = ori.TrimValues;
         }
 
         /// <summary>

--- a/src/IniParser/Configuration/IniParserConfiguration.cs
+++ b/src/IniParser/Configuration/IniParserConfiguration.cs
@@ -153,6 +153,16 @@ namespace IniParser.Configuration
         public bool TrimProperties { get; set; } = true;
 
         /// <summary>
+        ///     If set to true, it will trim the whitespace out of the value when parsing.
+        ///     If set to false, it will consider all the whitespace in the line as part of the
+        ///     value when extracting the key and values.
+        /// </summary>
+        /// <remarks>
+        ///     Defaults to true.
+        /// </remarks>
+        public bool TrimValues { get; set; } = true;
+
+        /// <summary>
         ///     If set to true, it will trim the whitespace out of the section name when parsing.
         ///     If set to false, it will consider all the whitespace in the line as part of the
         ///     section name.

--- a/src/IniParser/Configuration/IniScheme.cs
+++ b/src/IniParser/Configuration/IniScheme.cs
@@ -103,7 +103,7 @@ namespace IniParser.Configuration
         public string PropertyAssigmentString
         {
             get => string.IsNullOrWhiteSpace(_propertyAssigmentString) ? "=" : _propertyAssigmentString;
-            set => _propertyAssigmentString = value?.Trim();
+            set => _propertyAssigmentString = value;
         }
         
         #region IDeepCloneable<T> Members

--- a/src/IniParser/IniDataParser.cs
+++ b/src/IniParser/IniDataParser.cs
@@ -356,6 +356,10 @@ namespace IniParser
             if (Configuration.TrimProperties)
             {
                 key.Trim();
+            }
+
+            if (Configuration.TrimValues)
+            {
                 value.Trim();
             }
 


### PR DESCRIPTION
Add support for leading and trailing whitespace in property assignment string
setting as well as adding a new TrimValues option. Previously, which
TrimProperties controlled trimming both properties and values. Now, these
options can be configured separately